### PR TITLE
changes for warehouse ros mongo

### DIFF
--- a/fanuc_moveit_config/launch/warehouse.launch
+++ b/fanuc_moveit_config/launch/warehouse.launch
@@ -7,7 +7,7 @@
    <include file="$(find moveit_resources)/fanuc_moveit_config/launch/warehouse_settings.launch.xml" />
 
    <!-- Run the DB server -->
-   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros">
+   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">
       <param name="overwrite" value="false"/>
       <param name="database_path" value="$(arg moveit_warehouse_database_path)" />
    </node>


### PR DESCRIPTION
currently this will not launch with the latest version of moveit (kinetic) warehouse_ros_mongo is required as mongo_wrapper_ros.py is no longer in warehouse_ros