### PR TITLE
Add missing run depends for [robot|joint]_state_publisher

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,10 +8,14 @@
 
   <maintainer email="dave@dav.ee">Dave Coleman</maintainer>
 
-  <license>BSD</license>  
+  <license>BSD</license>
   <url type="website">http://moveit.ros.org</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit-resources</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+
 </package>


### PR DESCRIPTION
In https://github.com/ros-planning/moveit/pull/214 I switched our CI to build off of ``ros-base`` instead of ``ros-desktop-full``. This means many ROS packages are not installed by default, which uncovered missing dependencies in the python move_group test causing travis to [fail](https://travis-ci.org/ros-planning/moveit/jobs/159809406):

```
FAILURE: Test Fixture Nodes ['joint_state_publisher', 'robot_state_publisher'] failed to launch
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rostest/runner.py", line 121, in fn
    self.assert_(not failed, "Test Fixture Nodes %s failed to launch"%failed)
  File "/usr/lib/python2.7/unittest/case.py", line 422, in assertTrue
    raise self.failureException(msg)
```

Should fix https://github.com/ros-planning/moveit/pull/209