### PR TITLE
fanuc_moveit_config: cleanup definition of move_group capabilities

### DIFF
--- a/fanuc_moveit_config/launch/move_group.launch
+++ b/fanuc_moveit_config/launch/move_group.launch
@@ -48,20 +48,21 @@
       <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
       <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-      <!-- MoveGroup capabilities to load -->
-      <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-                                        move_group/MoveGroupExecuteService
-                                        move_group/MoveGroupExecuteTrajectoryAction
-                                        move_group/MoveGroupKinematicsService
-                                        move_group/MoveGroupMoveAction
-                                        move_group/MoveGroupPickPlaceAction
-                                        move_group/MoveGroupPlanService
-                                        move_group/MoveGroupQueryPlannersService
-                                        move_group/MoveGroupStateValidationService
-                                        move_group/MoveGroupGetPlanningSceneService
-                                        move_group/ApplyPlanningSceneService
-                                        move_group/ClearOctomapService
-                                        " />
+      <!-- load these non-default MoveGroup capabilities -->
+      <!--
+          <param name="capabilities" value="
+          a_package/AwsomeMotionPlanningCapability
+          another_package/GraspPlanningPipeline
+          " />
+      -->
+
+      <!-- inhibit these default MoveGroup capabilities -->
+      <!--
+          <param name="disable_capabilities" value="
+          move_group/MoveGroupKinematicsService
+          move_group/ClearOctomapService
+          " />
+      -->
 
       <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
       <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />

--- a/panda_moveit_config/launch/chomp_planning_pipeline.launch.xml
+++ b/panda_moveit_config/launch/chomp_planning_pipeline.launch.xml
@@ -1,15 +1,10 @@
 <launch>
-
    <!-- CHOMP Plugin for MoveIt! -->
    <arg name="planning_plugin" value="chomp_interface/CHOMPPlanner" />
-
    <arg name="start_state_max_bounds_error" value="0.1" />
 
    <param name="planning_plugin" value="$(arg planning_plugin)" />
    <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
-   <param name="collision_detector" value="Hybrid" />
-
    <rosparam command="load" file="$(find moveit_resources)/panda_moveit_config/config/chomp_planning.yaml" />
-
 </launch>


### PR DESCRIPTION
We have a new scheme to load all default capabilities since a while.
`MoveGroupExecuteService` was [obsoleted in Kinetic](https://github.com/ros-planning/moveit/pull/94) and [removed in Melodic](https://github.com/ros-planning/moveit/pull/833).

As of https://github.com/ros-planning/moveit/pull/1251, CHOMP uses automatically the hybrid collision detector. No need to manually configure it, which is too fragile by the way.