### PR TITLE
Port CMakeLists.txt & package.xml to ROS2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ notifications:
     recipients:
       - 130s@2000.jukuin.keio.ac.jp
 env:
+  global:
+    - ROS_DISTRO=eloquent
+    - ROS_REPO=ros
+    - UPSTREAM_WORKSPACE=moveit_resources.repos
   matrix:
-    - ROS_DISTRO="crystal"  ROS_REPO=ros
+    - ROS_DISTRO="eloquent"
 
 before_script:
   - git clone -b ros2 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,24 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_resources)
+find_package(ament_cmake REQUIRED)
 
-find_package(catkin REQUIRED)
-
-file(MAKE_DIRECTORY "${CATKIN_DEVEL_PREFIX}/include")
-catkin_package(INCLUDE_DIRS include "${CATKIN_DEVEL_PREFIX}/include")
-
-# devel space file
-set(MOVEIT_TEST_RESOURCES_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-configure_file("include/${PROJECT_NAME}/config.h.in" "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/config.h")
+file(MAKE_DIRECTORY "include")
+ament_export_include_directories(include "include/")
 
 # install space file
-set(MOVEIT_TEST_RESOURCES_DIR ${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
-configure_file("include/${PROJECT_NAME}/config.h.in" "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/.config_install.h")
+set(MOVEIT_TEST_RESOURCES_DIR ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME})
+configure_file("include/${PROJECT_NAME}/config.h.in" "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/.config_install.h")
+configure_file("include/${PROJECT_NAME}/config.h.in" "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/config.h")
 
 install(
   DIRECTORY pr2_description fanuc_description panda_description
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION "share/${PROJECT_NAME}")
+
 install(
-  FILES "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/.config_install.h"
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/.config_install.h"
+  DESTINATION include/${PROJECT_NAME}
   RENAME "config.h")
 
 # fanuc moveit config
-install(DIRECTORY fanuc_moveit_config panda_moveit_config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(DIRECTORY fanuc_moveit_config panda_moveit_config DESTINATION "share/${PROJECT_NAME}")
+ament_package()

--- a/moveit_resources.repos
+++ b/moveit_resources.repos
@@ -1,0 +1,5 @@
+repositories:
+  joint_state_publisher:
+    type: git
+    url: https://github.com/ros/joint_state_publisher
+    version: ros2-devel

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="3">
   <name>moveit_resources</name>
   <version>0.6.4</version>
   <description>Resources used for MoveIt! testing</description>
@@ -13,9 +14,12 @@
   <url type="bugtracker">https://github.com/ros-planning/moveit-resources/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit-resources</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
 
+  <export>
+      <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This PR apply the changes from [PR#24](https://github.com/ros-planning/moveit_resources/pull/24) for the CMakeLists.txt and package.xml (without porting Mara files)