### PR TITLE
Update joint_state_publisher dependency

### DIFF
--- a/moveit_resources.repos
+++ b/moveit_resources.repos
@@ -2,4 +2,4 @@ repositories:
   joint_state_publisher:
     type: git
     url: https://github.com/ros/joint_state_publisher
-    version: ros2-devel
+    version: ros2


### PR DESCRIPTION
It looks like the ros2-devel branch was deleted - I'm assuming it was renamed to simply ros2. As noted in https://github.com/ros-planning/moveit2/pull/200 the old reference can break CI.