### PR TITLE
remove solver attempts

### DIFF
--- a/fanuc_moveit_config/config/kinematics.yaml
+++ b/fanuc_moveit_config/config/kinematics.yaml
@@ -1,5 +1,4 @@
 manipulator:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3
+  kinematics_solver_timeout: 0.015

--- a/panda_moveit_config/config/kinematics.yaml
+++ b/panda_moveit_config/config/kinematics.yaml
@@ -1,5 +1,4 @@
 panda_arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.05
-  kinematics_solver_attempts: 5
+  kinematics_solver_timeout: 0.25


### PR DESCRIPTION
Increase timeout accordingly to keep roughly the same behavior.

Afaik kinetic still uses this branch as well, but should not be badly affected.
The default attempt count was 2 there.