### PR TITLE
Fix self-colliding 'extended' pose

### DIFF
--- a/panda_moveit_config/config/panda.srdf
+++ b/panda_moveit_config/config/panda.srdf
@@ -32,7 +32,7 @@
     <joint name="panda_joint3" value="0"/>
     <joint name="panda_joint4" value="0"/>
     <joint name="panda_joint5" value="0"/>
-    <joint name="panda_joint6" value="0"/>
+    <joint name="panda_joint6" value="1.571"/>
     <joint name="panda_joint7" value="0.785"/>
   </group_state>
   <group_state group="panda_arm" name="transport">

--- a/panda_moveit_config/config/panda_arm.xacro
+++ b/panda_moveit_config/config/panda_arm.xacro
@@ -25,7 +25,7 @@
       <joint name="panda_joint3" value="0" />
       <joint name="panda_joint4" value="0" />
       <joint name="panda_joint5" value="0" />
-      <joint name="panda_joint6" value="0" />
+      <joint name="panda_joint6" value="1.571" />
       <joint name="panda_joint7" value="0.785" />
     </group_state>
     <group_state name="transport" group="panda_arm">


### PR DESCRIPTION
I just noticed that the extended pose is in self collision (did the meshes change?):

![self-collision](https://user-images.githubusercontent.com/4572766/90414245-d1160000-e0af-11ea-9dd1-93d90c7705c7.png)

The updated pose looks like this:
![fixed](https://user-images.githubusercontent.com/4572766/90414518-2ce08900-e0b0-11ea-9455-f5289d595add.png)
