### PR TITLE
Removes kinetic from travis ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ notifications:
 env:
   matrix:
     - ROS_DISTRO="melodic"  ROS_REPO=ros
-    - ROS_DISTRO="kinetic"  ROS_REPO=ros
 
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   matrix:
+    - ROS_DISTRO="noetic"  ROS_REPO=ros
     - ROS_DISTRO="melodic"  ROS_REPO=ros
 
 before_script:


### PR DESCRIPTION
According to the removal of the kinetic CI in ros-planning/moveit  [#2294](https://github.com/ros-planning/moveit/pull/2295) the CI can/should? be removed from this repository as well.
It is already causing troubles see #43 