### PR TITLE
Prepare Noetic/Melodic release (0.7.2)

### DIFF
--- a/fanuc_description/CHANGELOG.rst
+++ b/fanuc_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources_fanuc_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/fanuc_description/package.xml
+++ b/fanuc_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_fanuc_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>Fanuc Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/fanuc_moveit_config/CHANGELOG.rst
+++ b/fanuc_moveit_config/CHANGELOG.rst
@@ -2,6 +2,63 @@
 Changelog for package moveit_resources_fanuc_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Dave Coleman, Henning Kayser
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/fanuc_moveit_config/package.xml
+++ b/fanuc_moveit_config/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>moveit_resources_fanuc_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Fanuc M-10iA.

--- a/moveit_resources/CHANGELOG.rst
+++ b/moveit_resources/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/moveit_resources/package.xml
+++ b/moveit_resources/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/panda_description/CHANGELOG.rst
+++ b/panda_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources_panda_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/panda_description/package.xml
+++ b/panda_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_panda_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>panda Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/panda_moveit_config/CHANGELOG.rst
+++ b/panda_moveit_config/CHANGELOG.rst
@@ -2,8 +2,66 @@
 Changelog for package moveit_resources_panda_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Update panda_moveit_config launch files, add use_rviz parameter (`#52 <https://github.com/ros-planning/moveit_resources/issues/52>`_)
+  Regenerated demo.launch and rviz.launch from setup assistant.
+  The main motivation for this change is the additional use_rviz argument
+  through which rviz can be disabled.
+  The `rviz_tutorial` parameter in moveit_rviz.launch was only ever used
+  through demo.launch and it's easier to handle the different rviz configurations there.
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Henning Kayser, Michael Görner
+
 * add execution_type and pilz pipeline to panda config
 * Contributors: Pilz GmbH and Co. KG
 

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_panda_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Franka Emika Panda

--- a/pr2_description/CHANGELOG.rst
+++ b/pr2_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources_pr2_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/pr2_description/package.xml
+++ b/pr2_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_pr2_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>PR2 Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
+++ b/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
@@ -2,6 +2,57 @@
 Changelog for package moveit_resources_prbt_ikfast_manipulator_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel
+
 * initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)

--- a/prbt_ikfast_manipulator_plugin/package.xml
+++ b/prbt_ikfast_manipulator_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <package format="2">
   <name>moveit_resources_prbt_ikfast_manipulator_plugin</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>The prbt_ikfast_manipulator_plugin package</description>
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -2,6 +2,58 @@
 Changelog for package moveit_resources_prbt_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Henning Kayser
+
 * initial commit from upstream PilzDE/prbt_movit_config version 0.5.18

--- a/prbt_moveit_config/package.xml
+++ b/prbt_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>moveit_resources_prbt_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Pilz PRBT 6

--- a/prbt_pg70_support/CHANGELOG.rst
+++ b/prbt_pg70_support/CHANGELOG.rst
@@ -2,6 +2,57 @@
 Changelog for package moveit_resources_prbt_pg70_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel
+
 * initial commit from upstream PilzDE/prbt_grippers version 0.0.4

--- a/prbt_pg70_support/package.xml
+++ b/prbt_pg70_support/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_resources_prbt_pg70_support</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>PRBT support for Schunk pg70 gripper.</description>
 
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -2,6 +2,57 @@
 Changelog for package prbt_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  * adding RPBT config
+  * removing roslaunch check becasue of removed dependencies
+  * adding pilz pipeline config for panda
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * drop no longer needed dependency
+  * add remaining prbt-related packages
+  * prbt_ikfast_manipulaor_plugin
+  * prbt_support
+  * prbt_pg70_support
+  * add argument to enable last point execution
+  to speed up test time by skipping trajectory in fake execution
+  * last point execution for pg70 gripper
+  * drop system_info
+  since we only need urdf model for testing in simulation
+  to get rid of dependency to pilz_testutils
+  * actually use pg70 package
+  inside from moveit_resources instead of schunk_description
+  * drop depend on prbt_hardware_support
+  not needed in simulation
+  * add execution type for panda config
+  to allow skipping execution and jump to last point in fake execution
+  * fixup 4bc2ce drop system_info
+  * fix roslaunch and CMakeLists checks
+  * also adding capabilities here
+  * drop more dependencies
+  * using pg70 support from moveit_resources
+  * add execution_type to gripper
+  * drop Werror
+  as suggested in the review by v4hn
+  * update deprecated macro to INSTANTIATE_TEST_SUITE_P
+  * Revert "update deprecated macro to INSTANTIATE_TEST_SUITE_P"
+  This reverts commit 1a467ccea675af7fe296ff8ba18c4f8bee9d53f0.
+  * update version numbers to be consitant across the meta-package
+  * version increase fo pilz packages
+  * removing patch files
+  * tiny fix
+  * update panda config from templates
+  re-generated from MSA with adapted templates
+  see moveit 99c059f
+  * update fanuc package from MSA
+  with updated templates, see moveit commit a4527b
+  * drop remapping to joint_states_desired
+  for easier include of move_group.launch into tests.
+  This brings the panda_moveit_config closer to the templates in MSA.
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel
+
 * initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>moveit_resources_prbt_support</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description> Mechanical, kinematic and visual description
   of the Pilz light weight arm PRBT. </description>
 


### PR DESCRIPTION
This should fix the official buildfarm issues for moveit1.  The pills robot packages have never been released for Noetic and Melodic and therefore aren't in rosdep yet.  This will add them.

Please let me know if releasing this would cause any issues.  My understanding is this is the first package we need to release.

I propose we rebase merge this as this PR doesn't need to exist past these commits.