### PR TITLE
Prepare Release for Noetic/Melodic 0.7.2

### DIFF
--- a/fanuc_description/CHANGELOG.rst
+++ b/fanuc_description/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources_fanuc_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/fanuc_description/CHANGELOG.rst
+++ b/fanuc_description/CHANGELOG.rst
@@ -4,9 +4,7 @@ Changelog for package moveit_resources_fanuc_description
 
 0.7.2 (2021-03-26)
 ------------------
-* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
-  * Change package maintainer to MoveIt Release Team
-  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Change package maintainer to MoveIt Release Team
 * Contributors: Dave Coleman
 
 0.7.1 (2020-10-09)

--- a/fanuc_description/package.xml
+++ b/fanuc_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_fanuc_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>Fanuc Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/fanuc_moveit_config/CHANGELOG.rst
+++ b/fanuc_moveit_config/CHANGELOG.rst
@@ -4,15 +4,11 @@ Changelog for package moveit_resources_fanuc_moveit_config
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
 * Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
-* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
-  * Change package maintainer to MoveIt Release Team
-  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel, Dave Coleman, Henning Kayser, Robert Haschke, Tyler Weaver
+* Change package maintainer to MoveIt Release Team
+* Contributors: Dave Coleman, Henning Kayser, Robert Haschke, Tyler Weaver
 
 0.7.1 (2020-10-09)
 ------------------

--- a/fanuc_moveit_config/CHANGELOG.rst
+++ b/fanuc_moveit_config/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package moveit_resources_fanuc_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Dave Coleman, Henning Kayser, Robert Haschke, Tyler Weaver
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/fanuc_moveit_config/package.xml
+++ b/fanuc_moveit_config/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>moveit_resources_fanuc_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Fanuc M-10iA.

--- a/moveit_resources/CHANGELOG.rst
+++ b/moveit_resources/CHANGELOG.rst
@@ -4,9 +4,7 @@ Changelog for package moveit_resources
 
 0.7.2 (2021-03-26)
 ------------------
-* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
-  * Change package maintainer to MoveIt Release Team
-  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Change package maintainer to MoveIt Release Team
 * Contributors: Dave Coleman
 
 0.7.1 (2020-10-09)

--- a/moveit_resources/CHANGELOG.rst
+++ b/moveit_resources/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package moveit_resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/moveit_resources/package.xml
+++ b/moveit_resources/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/panda_description/CHANGELOG.rst
+++ b/panda_description/CHANGELOG.rst
@@ -4,11 +4,9 @@ Changelog for package moveit_resources_panda_description
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
-* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
-  * Change package maintainer to MoveIt Release Team
-  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Change package maintainer to MoveIt Release Team
 * Contributors: Dave Coleman, Robert Haschke, Tyler Weaver
 
 0.7.1 (2020-10-09)

--- a/panda_description/CHANGELOG.rst
+++ b/panda_description/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package moveit_resources_panda_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman, Robert Haschke, Tyler Weaver
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/panda_description/package.xml
+++ b/panda_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_panda_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>panda Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/panda_moveit_config/CHANGELOG.rst
+++ b/panda_moveit_config/CHANGELOG.rst
@@ -4,21 +4,12 @@ Changelog for package moveit_resources_panda_moveit_config
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
 * Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
-* Update panda_moveit_config launch files, add use_rviz parameter (`#52 <https://github.com/ros-planning/moveit_resources/issues/52>`_)
-  Regenerated demo.launch and rviz.launch from setup assistant.
-  The main motivation for this change is the additional use_rviz argument
-  through which rviz can be disabled.
-  The `rviz_tutorial` parameter in moveit_rviz.launch was only ever used
-  through demo.launch and it's easier to handle the different rviz configurations there.
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel, Henning Kayser, Michael Görner, Robert Haschke, Tyler Weaver
-
-* add execution_type and pilz pipeline to panda config
-* Contributors: Pilz GmbH and Co. KG
+* Update panda_moveit_config launch files: add use_rviz parameter (`#52 <https://github.com/ros-planning/moveit_resources/issues/52>`_)
+* Add Pilz planner pipeline
+* Contributors: Christian Henkel, Joachim Schleicher, Henning Kayser, Michael Görner, Robert Haschke, Tyler Weaver
 
 0.7.1 (2020-10-09)
 ------------------

--- a/panda_moveit_config/CHANGELOG.rst
+++ b/panda_moveit_config/CHANGELOG.rst
@@ -2,8 +2,21 @@
 Changelog for package moveit_resources_panda_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Update panda_moveit_config launch files, add use_rviz parameter (`#52 <https://github.com/ros-planning/moveit_resources/issues/52>`_)
+  Regenerated demo.launch and rviz.launch from setup assistant.
+  The main motivation for this change is the additional use_rviz argument
+  through which rviz can be disabled.
+  The `rviz_tutorial` parameter in moveit_rviz.launch was only ever used
+  through demo.launch and it's easier to handle the different rviz configurations there.
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Henning Kayser, Michael Görner, Robert Haschke, Tyler Weaver
+
 * add execution_type and pilz pipeline to panda config
 * Contributors: Pilz GmbH and Co. KG
 

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_panda_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Franka Emika Panda

--- a/pr2_description/CHANGELOG.rst
+++ b/pr2_description/CHANGELOG.rst
@@ -4,11 +4,9 @@ Changelog for package moveit_resources_pr2_description
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
-* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
-  * Change package maintainer to MoveIt Release Team
-  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Change package maintainer to MoveIt Release Team
 * Contributors: Dave Coleman, Robert Haschke, Tyler Weaver
 
 0.7.1 (2020-10-09)

--- a/pr2_description/CHANGELOG.rst
+++ b/pr2_description/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package moveit_resources_pr2_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Change package maintainer: Dave to Robert (`#49 <https://github.com/ros-planning/moveit_resources/issues/49>`_)
+  * Change package maintainer to MoveIt Release Team
+  Co-authored-by: Robert Haschke <rhaschke@techfak.uni-bielefeld.de>
+* Contributors: Dave Coleman, Robert Haschke, Tyler Weaver
+
 0.7.1 (2020-10-09)
 ------------------
 

--- a/pr2_description/package.xml
+++ b/pr2_description/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>moveit_resources_pr2_description</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>PR2 Resources used for MoveIt! testing</description>
 
   <author email="isucan@willowgarage.edu">Ioan Sucan</author>

--- a/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
+++ b/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package moveit_resources_prbt_ikfast_manipulator_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel
+
 * initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)

--- a/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
+++ b/prbt_ikfast_manipulator_plugin/CHANGELOG.rst
@@ -4,8 +4,5 @@ Changelog for package moveit_resources_prbt_ikfast_manipulator_plugin
 
 0.7.2 (2021-03-26)
 ------------------
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel
-
-* initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)
+* Adding PRBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+* Contributors: Christian Henkel, Joachim Schleicher

--- a/prbt_ikfast_manipulator_plugin/package.xml
+++ b/prbt_ikfast_manipulator_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <package format="2">
   <name>moveit_resources_prbt_ikfast_manipulator_plugin</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>The prbt_ikfast_manipulator_plugin package</description>
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package moveit_resources_prbt_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Henning Kayser
+
 * initial commit from upstream PilzDE/prbt_movit_config version 0.5.18

--- a/prbt_moveit_config/CHANGELOG.rst
+++ b/prbt_moveit_config/CHANGELOG.rst
@@ -5,8 +5,5 @@ Changelog for package moveit_resources_prbt_moveit_config
 0.7.2 (2021-03-26)
 ------------------
 * Run multiple planning pipelines with MoveGroup (`#47 <https://github.com/ros-planning/moveit_resources/issues/47>`_)
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel, Henning Kayser
-
-* initial commit from upstream PilzDE/prbt_movit_config version 0.5.18
+* Adding PRBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+* Contributors: Christian Henkel, Joachim Schleicher, Henning Kayser

--- a/prbt_moveit_config/package.xml
+++ b/prbt_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>moveit_resources_prbt_moveit_config</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     <p>
       MoveIt Resources for testing: Pilz PRBT 6

--- a/prbt_pg70_support/CHANGELOG.rst
+++ b/prbt_pg70_support/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package moveit_resources_prbt_pg70_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Robert Haschke, Tyler Weaver
+
 * initial commit from upstream PilzDE/prbt_grippers version 0.0.4

--- a/prbt_pg70_support/CHANGELOG.rst
+++ b/prbt_pg70_support/CHANGELOG.rst
@@ -4,10 +4,9 @@ Changelog for package moveit_resources_prbt_pg70_support
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel, Robert Haschke, Tyler Weaver
+* Adding PRBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+* Contributors: Christian Henkel, Joachim Schleicher, Robert Haschke, Tyler Weaver
 
 * initial commit from upstream PilzDE/prbt_grippers version 0.0.4

--- a/prbt_pg70_support/package.xml
+++ b/prbt_pg70_support/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_resources_prbt_pg70_support</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>PRBT support for Schunk pg70 gripper.</description>
 
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -4,10 +4,9 @@ Changelog for package prbt_support
 
 0.7.2 (2021-03-26)
 ------------------
-* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Migrate to GitHub Actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
 * Fix formatting issues
-* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
-  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
-* Contributors: Christian Henkel, Robert Haschke, Tyler Weaver
+* Adding PRBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+* Contributors: Christian Henkel, Joachim Schleicher, Robert Haschke, Tyler Weaver
 
 * initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)

--- a/prbt_support/CHANGELOG.rst
+++ b/prbt_support/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package prbt_support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2021-03-26)
+------------------
+* Master GitHub actions (`#57 <https://github.com/ros-planning/moveit_resources/issues/57>`_)
+* Fix formatting issues
+* Adding RPBT config (`#43 <https://github.com/ros-planning/moveit_resources/issues/43>`_)
+  Co-authored-by: Joachim Schleicher <J.Schleicher@pilz.de>
+* Contributors: Christian Henkel, Robert Haschke, Tyler Weaver
+
 * initial commit from upstream PilzDE/pilz_robots version 0.5.19 (2020-09-07)

--- a/prbt_support/package.xml
+++ b/prbt_support/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>moveit_resources_prbt_support</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description> Mechanical, kinematic and visual description
   of the Pilz light weight arm PRBT. </description>
 


### PR DESCRIPTION
This should fix the official build farm issues with moveit because it releases the Pilz robots.

lmk if this will cause any issues.  My understanding is that in order to do a melodic/noetic release we need to first release this.