### PR TITLE
Let users specify fake execution type for demo.launch

### DIFF
--- a/fanuc_moveit_config/launch/demo.launch
+++ b/fanuc_moveit_config/launch/demo.launch
@@ -11,6 +11,9 @@
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
 
+  <!-- Set execution mode for fake execution controllers -->
+  <arg name="execution_type" default="interpolate" />
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -43,6 +46,7 @@
   <include file="$(find moveit_resources_fanuc_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
+    <arg name="execution_type" value="$(arg execution_type)"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/panda_moveit_config/launch/demo.launch
+++ b/panda_moveit_config/launch/demo.launch
@@ -14,6 +14,9 @@
   <!-- By default, we will load or override the robot_description -->
   <arg name="load_robot_description" default="true"/>
 
+  <!-- Override execution type for fake controllers -->
+  <arg name="execution_type" default="interpolate" />
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -45,6 +48,7 @@
   <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
+    <arg name="execution_type" value="$(arg execution_type)"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -11,6 +11,9 @@
   <!-- By default, we are not in debug mode -->
   <arg name="debug" default="false" />
 
+  <!-- Set execution mode for fake execution controllers -->
+  <arg name="execution_type" default="interpolate" />
+
   <!--
   By default, hide joint_state_publisher's GUI
 
@@ -42,6 +45,7 @@
   <include file="$(find moveit_resources_prbt_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
+    <arg name="execution_type" value="$(arg execution_type)"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>


### PR DESCRIPTION
Required to invoke demo.launch use_rviz:=false with execution speedup for tests.

See https://github.com/ros-planning/moveit/pull/2602
for the corresponding patch in the setup assistant.