### PR TITLE
Remove move group prefixes from rviz configs

### DIFF
--- a/fanuc_moveit_config/launch/moveit.rviz
+++ b/fanuc_moveit_config/launch/moveit.rviz
@@ -331,7 +331,7 @@ Visualization Manager:
         Show Robot Visual: true
         Show Trail: false
         State Display Time: 0.05 s
-        Trajectory Topic: move_group/display_planned_path
+        Trajectory Topic: /display_planned_path
       Planning Metrics:
         Payload: 1
         Show Joint Torques: false
@@ -350,7 +350,7 @@ Visualization Manager:
         Show Workspace: false
         Start State Alpha: 1
         Start State Color: 0; 255; 0
-      Planning Scene Topic: move_group/monitored_planning_scene
+      Planning Scene Topic: /monitored_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 1

--- a/panda_moveit_config/launch/moveit.rviz
+++ b/panda_moveit_config/launch/moveit.rviz
@@ -129,13 +129,13 @@ Visualization Manager:
       Show Trail: false
       State Display Time: 0.05 s
       Trail Step Size: 1
-      Trajectory Topic: /move_group/display_planned_path
+      Trajectory Topic: /display_planned_path
       Value: true
     - Class: moveit_rviz_plugin/PlanningScene
       Enabled: true
       Move Group Namespace: ""
       Name: PlanningScene
-      Planning Scene Topic: /move_group/monitored_planning_scene
+      Planning Scene Topic: /monitored_planning_scene
       Robot Description: robot_description
       Scene Geometry:
         Scene Alpha: 0.899999976


### PR DESCRIPTION
Relates to https://github.com/ros-planning/moveit2_tutorials/pull/69 and https://github.com/ros-planning/moveit2/pull/420