### PR TITLE
remove melodic from master branch CI

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: melodic, ROS_REPO: main}
           - {ROS_DISTRO: noetic, ROS_REPO: main}
           - {ROS_DISTRO: noetic, ROS_REPO: testing}
     env:


### PR DESCRIPTION
I already pushed `melodic-devel` as a new branch directly and setup branch protection rules.

The next releases (which should happen soon to cleanup the melodic issues) should bump the patch version in the `melodic-devel` branch and the minor version in `master` to leave room for future melodic releases.