### PR TITLE
Add missing ros2_control parameters

### DIFF
--- a/panda_moveit_config/config/panda_ros_controllers.yaml
+++ b/panda_moveit_config/config/panda_ros_controllers.yaml
@@ -11,6 +11,11 @@ controller_manager:
 
 panda_arm_controller:
   ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
     joints:
       - panda_joint1
       - panda_joint2


### PR DESCRIPTION
These are required per https://github.com/ros-controls/ros2_controllers/commit/612f610c24d026a41abd2dd026902c672cf778c9 and for fixing CI (https://github.com/ros-planning/moveit2/runs/2633357612#step:7:6223)