### PR TITLE
remove ompl TrajOpt planner config

### DIFF
--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -120,8 +120,6 @@ planner_configs:
     sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
-  TrajOptDefault:
-    type: geometric::TrajOpt
 
 panda_arm:
   default_planner_config: RRTConnectkConfigDefault
@@ -149,7 +147,6 @@ panda_arm:
     - LazyPRMstarkConfigDefault
     - SPARSkConfigDefault
     - SPARStwokConfigDefault
-    - TrajOptDefault
 panda_arm_hand:
   planner_configs:
     - SBLkConfigDefault
@@ -175,7 +172,6 @@ panda_arm_hand:
     - LazyPRMstarkConfigDefault
     - SPARSkConfigDefault
     - SPARStwokConfigDefault
-    - TrajOptDefault
 hand:
   planner_configs:
     - SBLkConfigDefault
@@ -201,4 +197,3 @@ hand:
     - LazyPRMstarkConfigDefault
     - SPARSkConfigDefault
     - SPARStwokConfigDefault
-    - TrajOptDefault


### PR DESCRIPTION
This planner is not available upstream in OMPL for now
- it's work in progress to the best of my knowledge.

It can easily confuse users to have the option available here
when it will not plan anything but complain on the command line
that the solver does not exist...

@mamoll