### PR TITLE
Restore virtual joint type to fixed in SRDF

### DIFF
--- a/panda_moveit_config/config/panda_arm.xacro
+++ b/panda_moveit_config/config/panda_arm.xacro
@@ -39,7 +39,7 @@
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="virtual_joint" type="floating" parent_frame="world" child_link="panda_link0" />
+    <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="panda_link0" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="panda_link0" link2="panda_link1" reason="Adjacent" />
     <disable_collisions link1="panda_link0" link2="panda_link2" reason="Never" />

--- a/panda_moveit_config/launch/demo.launch
+++ b/panda_moveit_config/launch/demo.launch
@@ -29,9 +29,6 @@
   <arg name="use_gui" default="false" />
   <arg name="use_rviz" default="true" />
 
-  <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
-
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">


### PR DESCRIPTION
The virtual joint type set to `floating` seems to break things when doing benchmarks with the _moveit_ros_benchmarks_ package. 

The first issue I had was with STOMP with cartesian goal constraints which you can read [here](https://github.com/ros-industrial/stomp_ros/issues/34). Changing the joint type to fixed resolves the problem but it may not be the culprit.

The second issue is only occurring when I populate a scene with meshes (tried different meshes and reduced to only one). The left image is a joint constraint goal and the blue line is the path retrieved from STOMP. The left end of the path is the start state and the right end of the segment is the goal state. The left image is with the fixed virtual joint and is the correct planning scene. The right image was taken with the virtual joint as floating. This changes the TF from the _world_ frame to the _panda_link0_ frame for an unknown reason. This also affects OMPL planners. Using this scene with SolidPrimitives and the virtual joint set to float dosen't produce the error, only meshes.

<p align="middle">
<img src="https://user-images.githubusercontent.com/32679594/123027466-e6347d00-d3ab-11eb-9dad-b7754588a94b.png" width="42.6%" />
<img src="https://user-images.githubusercontent.com/32679594/123027732-580cc680-d3ac-11eb-84bf-9d429e74c1be.png" width="48%" /> 
</p>

The comment in the SRDF says "considered **fixed** with respect to the robot" but the joint is floating... The first commits had the fixed type but was changed to floating [here](https://github.com/ros-planning/moveit_resources/commit/986a6e370bbe04687a85e9c39baf8d3720e458e4#diff-25497f5771ae45d7d05cecd00879481626a3072006f7ea4e6e7572a3fb0bab50).

I did not investigate further but I can replicate the behavior  everytime.