### PR TITLE
add planner_adapter setMaxCartesianLinkSpeed to panda_arm

### DIFF
--- a/panda_moveit_config/launch/ompl_planning_pipeline.launch.xml
+++ b/panda_moveit_config/launch/ompl_planning_pipeline.launch.xml
@@ -6,7 +6,8 @@
   <!-- The request adapters (plugins) used when planning with OMPL.
        ORDER MATTERS -->
   <arg name="planning_adapters"
-       value="default_planner_request_adapters/AddTimeParameterization
+       value="default_planner_request_adapters/setMaxCartesianLinkSpeed
+              default_planner_request_adapters/AddTimeParameterization
               default_planner_request_adapters/ResolveConstraintFrames
               default_planner_request_adapters/FixWorkspaceBounds
               default_planner_request_adapters/FixStartStateBounds

--- a/panda_moveit_config/launch/trajopt_planning_pipeline.launch.xml
+++ b/panda_moveit_config/launch/trajopt_planning_pipeline.launch.xml
@@ -5,7 +5,8 @@
 
   <!-- The request adapters (plugins) used when planning with TrajOpt.
        ORDER MATTERS -->
-  <arg name="planning_adapters" value="default_planner_request_adapters/AddTimeParameterization
+  <arg name="planning_adapters" value="default_planner_request_adapters/setMaxCartesianLinkSpeed
+               default_planner_request_adapters/AddTimeParameterization
 				       default_planner_request_adapters/FixWorkspaceBounds
 				       default_planner_request_adapters/FixStartStateBounds
 				       default_planner_request_adapters/FixStartStateCollision


### PR DESCRIPTION
Required to set max cartesian speed in MTC demos https://github.com/ros-planning/moveit_task_constructor/pull/277
Requires:
- https://github.com/ros-planning/moveit/pull/2674
- https://github.com/ros-planning/moveit_msgs/pull/122

