### PR TITLE
Migrate to joint state broadcaster

### DIFF
--- a/fanuc_moveit_config/config/ros_controllers.yaml
+++ b/fanuc_moveit_config/config/ros_controllers.yaml
@@ -18,8 +18,8 @@ hardware_interface:
   sim_control_mode: 1  # 0: position, 1: velocity
 # Publish all joint states
 # Creates the /joint_states topic necessary in ROS
-joint_state_controller:
-  type: joint_state_controller/JointStateController
+joint_state_broadcaster:
+  type: joint_state_broadcaster/JointStateBroadcaster
   publish_rate: 50
 controller_list:
   - name: manipulator_controller

--- a/panda_moveit_config/config/panda_ros_controllers.yaml
+++ b/panda_moveit_config/config/panda_ros_controllers.yaml
@@ -9,7 +9,7 @@ controller_manager:
       type: position_controllers/GripperActionController
 
     joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateController
+      type: joint_state_broadcaster/JointStateBroadcaster
 
 
 panda_arm_controller:

--- a/panda_moveit_config/config/panda_ros_controllers.yaml
+++ b/panda_moveit_config/config/panda_ros_controllers.yaml
@@ -8,8 +8,8 @@ controller_manager:
     panda_hand_controller:
       type: position_controllers/GripperActionController
 
-    joint_state_controller:
-      type: joint_state_controller/JointStateController
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateController
 
 
 panda_arm_controller:

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -186,7 +186,7 @@ def generate_launch_description():
 
     # Load controllers
     load_controllers = []
-    for controller in ["panda_arm_controller", "panda_hand_controller", "joint_state_controller"]:
+    for controller in ["panda_arm_controller", "panda_hand_controller", "joint_state_broadcaster"]:
         load_controllers += [
             ExecuteProcess(
                 cmd=["ros2 run controller_manager spawner.py {}".format(controller)],


### PR DESCRIPTION
With https://github.com/ros-controls/ros2_controllers/pull/230 ros2_control now removed joint_state_controller in favor of joint_state_broadcaster. This PR migrates `moveit_resources` to joint_state_broadcaster