### PR TITLE
add missing broadcaster for virtual joint back

### DIFF
--- a/panda_moveit_config/launch/demo.launch
+++ b/panda_moveit_config/launch/demo.launch
@@ -29,6 +29,8 @@
   <arg name="use_gui" default="false" />
   <arg name="use_rviz" default="true" />
 
+  <!-- If needed, broadcast static tf for robot root -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" />
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">


### PR DESCRIPTION
https://github.com/ros-planning/moveit/pull/2769 changed the MSA to always generate the static broadcaster for virtual joints.
This repairs the panda moveit config to include this virtual joint again.

Required to fix MTC pick-place demo.

Fixes #89