### PR TITLE
Simplify launch files

### DIFF
--- a/fanuc_moveit_config/config/fake_controllers.yaml
+++ b/fanuc_moveit_config/config/fake_controllers.yaml
@@ -1,6 +1,6 @@
 controller_list:
   - name: fake_manipulator_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - joint_1
       - joint_2

--- a/fanuc_moveit_config/launch/default_warehouse_db.launch
+++ b/fanuc_moveit_config/launch/default_warehouse_db.launch
@@ -5,7 +5,7 @@
   <arg name="moveit_warehouse_database_path" default="$(find moveit_resources_fanuc_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- Launch the warehouse with the configured database location -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 

--- a/fanuc_moveit_config/launch/demo.launch
+++ b/fanuc_moveit_config/launch/demo.launch
@@ -12,7 +12,7 @@
   <arg name="debug" default="false" />
 
   <!-- Set execution mode for fake execution controllers -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!--
   By default, hide joint_state_publisher's GUI
@@ -46,7 +46,7 @@
   <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
-    <arg name="execution_type" value="$(arg execution_type)"/>
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/fanuc_moveit_config/launch/demo.launch
+++ b/fanuc_moveit_config/launch/demo.launch
@@ -26,12 +26,12 @@
   <arg name="use_rviz" default="true" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->
-  
+
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
@@ -43,7 +43,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="execution_type" value="$(arg execution_type)"/>
@@ -53,13 +53,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/moveit_rviz.launch" if="$(arg use_rviz)">
-    <arg name="rviz_config" value="$(find moveit_resources_fanuc_moveit_config)/launch/moveit.rviz"/>
+  <include file="$(dirname)/moveit_rviz.launch" if="$(arg use_rviz)">
+    <arg name="rviz_config" value="$(dirname)/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/fanuc_moveit_config/launch/demo_chomp.launch
+++ b/fanuc_moveit_config/launch/demo_chomp.launch
@@ -9,7 +9,7 @@
   <arg name="debug" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
@@ -26,7 +26,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
@@ -35,13 +35,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/moveit_rviz.launch">
+  <include file="$(dirname)/moveit_rviz.launch">
     <arg name="config" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/fanuc_moveit_config/launch/demo_gazebo.launch
+++ b/fanuc_moveit_config/launch/demo_gazebo.launch
@@ -25,19 +25,19 @@
   <arg name="urdf_path" default="$(find moveit_resources_fanuc_description)/urdf/fanuc.urdf"/>
 
   <!-- launch the gazebo simulator and spawn the robot -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/gazebo.launch" >
+  <include file="$(dirname)/gazebo.launch" >
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gazebo_gui" value="$(arg gazebo_gui)"/>
     <arg name="urdf_path" value="$(arg urdf_path)"/>
   </include>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="false"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->
-  
+
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
@@ -49,21 +49,21 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-  </include>  
+  </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="rviz_config" value="$(find moveit_resources_fanuc_moveit_config)/launch/moveit.rviz"/>
+  <include file="$(dirname)/moveit_rviz.launch">
+    <arg name="rviz_config" value="$(dirname)/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/fanuc_moveit_config/launch/fake_moveit_controller_manager.launch.xml
+++ b/fanuc_moveit_config/launch/fake_moveit_controller_manager.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- execute the trajectory in 'interpolate' mode or jump to goal position in 'last point' mode -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
   <param name="moveit_controller_manager" value="moveit_fake_controller_manager/MoveItFakeControllerManager"/>

--- a/fanuc_moveit_config/launch/gazebo.launch
+++ b/fanuc_moveit_config/launch/gazebo.launch
@@ -18,6 +18,6 @@
   <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -x 0 -y 0 -z 0"
     respawn="false" output="screen" />
 
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/ros_controllers.launch"/>
+  <include file="$(dirname)/ros_controllers.launch" />
 
 </launch>

--- a/fanuc_moveit_config/launch/move_group.launch
+++ b/fanuc_moveit_config/launch/move_group.launch
@@ -14,7 +14,7 @@
   <arg name="pipeline" default="ompl" />
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
-  <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
+  <arg name="fake_execution_type" default="interpolate" /> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
@@ -68,7 +68,7 @@
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="fanuc" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
   <!-- Sensors Functionality -->

--- a/fanuc_moveit_config/launch/move_group.launch
+++ b/fanuc_moveit_config/launch/move_group.launch
@@ -3,8 +3,7 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix"
-	   value="gdb -x $(find moveit_resources_fanuc_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
+  <arg if="$(arg debug)" name="launch_prefix" value="gdb -x $(dirname)/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />
@@ -40,33 +39,32 @@
 
   <arg name="load_robot_description" default="true" />
   <!-- load URDF, SRDF and joint_limits configuration -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
   </include>
 
   <!-- Planning Pipelines -->
   <group ns="move_group/planning_pipelines">
-    <include ns="ompl" file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
-    <include ns="chomp" file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
-    <include ns="pilz_industrial_motion_planner" file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Load non-default planner if passed as parameter -->
-    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)"
-             file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
   </group>
 
   <!-- Trajectory Execution Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_fanuc_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="fanuc" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
@@ -74,7 +72,7 @@
   </include>
 
   <!-- Sensors Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_fanuc_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_sensor_manager" value="fanuc" />
   </include>
 

--- a/fanuc_moveit_config/launch/planning_pipeline.launch.xml
+++ b/fanuc_moveit_config/launch/planning_pipeline.launch.xml
@@ -5,6 +5,6 @@
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>

--- a/fanuc_moveit_config/launch/run_benchmark_ompl.launch
+++ b/fanuc_moveit_config/launch/run_benchmark_ompl.launch
@@ -4,12 +4,12 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_ompl_benchmark_warehouse"/>
   </include>
 

--- a/fanuc_moveit_config/launch/sensor_manager.launch.xml
+++ b/fanuc_moveit_config/launch/sensor_manager.launch.xml
@@ -12,6 +12,6 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="fanuc" />
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  <include file="$(dirname)/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
 
 </launch>

--- a/fanuc_moveit_config/launch/test_environment.launch
+++ b/fanuc_moveit_config/launch/test_environment.launch
@@ -1,6 +1,6 @@
 <launch>
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/demo.launch">
-    <arg name="use_gui" value="false"/>
-    <arg name="use_rviz" value="false"/>
+  <include file="$(dirname)/demo.launch" pass_all_args="true">
+    <arg name="use_gui" value="false" />
+    <arg name="use_rviz" value="false" />
   </include>
 </launch>

--- a/fanuc_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_moveit_config/launch/trajectory_execution.launch.xml
@@ -17,7 +17,7 @@
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc" />
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
+  <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="execution_type" value="$(arg execution_type)" />
   </include>
 

--- a/fanuc_moveit_config/launch/trajectory_execution.launch.xml
+++ b/fanuc_moveit_config/launch/trajectory_execution.launch.xml
@@ -2,7 +2,7 @@
 
   <!-- This file makes it easy to include the settings for trajectory execution  -->
 
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- Flag indicating whether MoveIt is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>
@@ -18,7 +18,7 @@
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="fanuc" />
   <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
 </launch>

--- a/fanuc_moveit_config/launch/warehouse.launch
+++ b/fanuc_moveit_config/launch/warehouse.launch
@@ -4,7 +4,7 @@
   <arg name="moveit_warehouse_database_path" />
 
   <!-- Load warehouse parameters -->
-  <include file="$(find moveit_resources_fanuc_moveit_config)/launch/warehouse_settings.launch.xml" />
+  <include file="$(dirname)/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">

--- a/panda_moveit_config/config/fake_controllers.yaml
+++ b/panda_moveit_config/config/fake_controllers.yaml
@@ -1,6 +1,6 @@
 controller_list:
   - name: fake_panda_arm_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - panda_joint1
       - panda_joint2
@@ -10,7 +10,7 @@ controller_list:
       - panda_joint6
       - panda_joint7
   - name: fake_hand_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - panda_finger_joint1
       - panda_finger_joint2

--- a/panda_moveit_config/launch/default_warehouse_db.launch
+++ b/panda_moveit_config/launch/default_warehouse_db.launch
@@ -5,7 +5,7 @@
   <arg name="moveit_warehouse_database_path" default="$(find moveit_resources_panda_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- Launch the warehouse with the configured database location -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 

--- a/panda_moveit_config/launch/demo.launch
+++ b/panda_moveit_config/launch/demo.launch
@@ -44,7 +44,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="execution_type" value="$(arg execution_type)"/>
@@ -55,14 +55,14 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/moveit_rviz.launch" if="$(arg use_rviz)">
-    <arg name="rviz_config" value="$(find moveit_resources_panda_moveit_config)/launch/moveit.rviz" unless="$(arg rviz_tutorial)"/>
-    <arg name="rviz_config" value="$(find moveit_resources_panda_moveit_config)/launch/moveit_empty.rviz" if="$(arg rviz_tutorial)"/>
+  <include file="$(dirname)/moveit_rviz.launch" if="$(arg use_rviz)">
+    <arg name="rviz_config" value="$(dirname)/moveit.rviz" unless="$(arg rviz_tutorial)" />
+    <arg name="rviz_config" value="$(dirname)/moveit_empty.rviz" if="$(arg rviz_tutorial)" />
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/panda_moveit_config/launch/demo.launch
+++ b/panda_moveit_config/launch/demo.launch
@@ -15,7 +15,7 @@
   <arg name="load_robot_description" default="true"/>
 
   <!-- Override execution type for fake controllers -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!--
   By default, hide joint_state_publisher's GUI
@@ -47,7 +47,7 @@
   <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
-    <arg name="execution_type" value="$(arg execution_type)"/>
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/panda_moveit_config/launch/demo_chomp.launch
+++ b/panda_moveit_config/launch/demo_chomp.launch
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/demo.launch">
+  <include file="$(dirname)/demo.launch">
     <arg name="pipeline" value="chomp"/>
   </include>
 </launch>

--- a/panda_moveit_config/launch/fake_moveit_controller_manager.launch.xml
+++ b/panda_moveit_config/launch/fake_moveit_controller_manager.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <!-- execute the trajectory in 'interpolate' mode or jump to goal position in 'last point' mode -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
   <param name="moveit_controller_manager" value="moveit_fake_controller_manager/MoveItFakeControllerManager"/>

--- a/panda_moveit_config/launch/move_group.launch
+++ b/panda_moveit_config/launch/move_group.launch
@@ -20,7 +20,7 @@
   <arg name="pipeline" default="ompl" />
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
-  <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
+  <arg name="fake_execution_type" default="interpolate" /> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
@@ -80,7 +80,7 @@
     <arg name="moveit_controller_manager" value="panda" if="$(eval not arg('fake_execution') and not arg('load_gripper'))"/>
     <arg name="moveit_controller_manager" value="panda_gripper" if="$(eval not arg('fake_execution') and arg('load_gripper'))"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
   <!-- Sensors Functionality -->

--- a/panda_moveit_config/launch/move_group.launch
+++ b/panda_moveit_config/launch/move_group.launch
@@ -2,15 +2,14 @@
 
   <arg name="load_gripper" default="true" />
 
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_gripper" value="$(arg load_gripper)" />
   </include>
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix"
-	   value="gdb -x $(find moveit_resources_panda_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
+  <arg if="$(arg debug)" name="launch_prefix" value="gdb -x $(dirname)/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />
@@ -46,7 +45,7 @@
 
   <arg name="load_robot_description" default="true" />
   <!-- load URDF, SRDF and joint_limits configuration -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
   </include>
 
@@ -54,30 +53,29 @@
   <group ns="move_group/planning_pipelines">
 
     <!-- OMPL -->
-    <include ns="ompl" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
     <!-- CHOMP -->
-    <include ns="chomp" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="chomp" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="chomp" />
     </include>
 
     <!-- Pilz Industrial Motion -->
-    <include ns="pilz_industrial_motion_planner" file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Load non-default planner if passed as parameter -->
-    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)"
-             file="$(find moveit_resources_panda_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include if="$(eval arg('pipeline') not in ['ompl', 'chomp', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
 
   </group>
 
   <!-- Trajectory Execution Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_panda_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="panda" if="$(eval not arg('fake_execution') and not arg('load_gripper'))"/>
     <arg name="moveit_controller_manager" value="panda_gripper" if="$(eval not arg('fake_execution') and arg('load_gripper'))"/>
@@ -86,7 +84,7 @@
   </include>
 
   <!-- Sensors Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_panda_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_sensor_manager" value="panda" />
   </include>
 

--- a/panda_moveit_config/launch/ompl-chomp_planning_pipeline.launch.xml
+++ b/panda_moveit_config/launch/ompl-chomp_planning_pipeline.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- load OMPL planning pipeline, but add the CHOMP planning adapter. -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml">
+  <include file="$(dirname)/ompl_planning_pipeline.launch.xml">
     <arg name="planning_adapters" value="
        default_planner_request_adapters/AddTimeParameterization
        default_planner_request_adapters/FixWorkspaceBounds

--- a/panda_moveit_config/launch/panda_moveit.launch
+++ b/panda_moveit_config/launch/panda_moveit.launch
@@ -4,7 +4,7 @@
 
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="position_joint_trajectory_controller"/>
 
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="load_gripper" value="$(arg load_gripper)" />
   </include>
 </launch>

--- a/panda_moveit_config/launch/planning_pipeline.launch.xml
+++ b/panda_moveit_config/launch/planning_pipeline.launch.xml
@@ -5,6 +5,6 @@
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>

--- a/panda_moveit_config/launch/run_benchmark_ompl.launch
+++ b/panda_moveit_config/launch/run_benchmark_ompl.launch
@@ -4,14 +4,14 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_ompl_benchmark_warehouse"/>
-  </include>  
+  </include>
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">

--- a/panda_moveit_config/launch/run_benchmark_trajopt.launch
+++ b/panda_moveit_config/launch/run_benchmark_trajopt.launch
@@ -4,12 +4,12 @@
   <arg name="trajopt_config" />
 
   <!-- Load URDF -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_trajopt_benchmark_warehouse"/>
   </include>
 

--- a/panda_moveit_config/launch/sensor_manager.launch.xml
+++ b/panda_moveit_config/launch/sensor_manager.launch.xml
@@ -13,6 +13,6 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="panda" />
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+  <include file="$(dirname)/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
 
 </launch>

--- a/panda_moveit_config/launch/trajectory_execution.launch.xml
+++ b/panda_moveit_config/launch/trajectory_execution.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <!-- This file makes it easy to include the settings for trajectory execution  -->  
+  <!-- This file makes it easy to include the settings for trajectory execution  -->
 
   <arg name="execution_type" default="interpolate" />
 
@@ -14,11 +14,11 @@
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
-  
+
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="panda" />
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
+  <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="execution_type" value="$(arg execution_type)" />
   </include>
-  
+
 </launch>

--- a/panda_moveit_config/launch/trajectory_execution.launch.xml
+++ b/panda_moveit_config/launch/trajectory_execution.launch.xml
@@ -2,7 +2,7 @@
 
   <!-- This file makes it easy to include the settings for trajectory execution  -->
 
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>
@@ -18,7 +18,7 @@
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="panda" />
   <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
 </launch>

--- a/panda_moveit_config/launch/warehouse.launch
+++ b/panda_moveit_config/launch/warehouse.launch
@@ -1,10 +1,10 @@
 <launch>
-  
+
   <!-- The path to the database must be specified -->
   <arg name="moveit_warehouse_database_path" />
 
-  <!-- Load warehouse parameters -->  
-  <include file="$(find moveit_resources_panda_moveit_config)/launch/warehouse_settings.launch.xml" />
+  <!-- Load warehouse parameters -->
+  <include file="$(dirname)/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">

--- a/prbt_moveit_config/config/fake_controllers.yaml
+++ b/prbt_moveit_config/config/fake_controllers.yaml
@@ -1,6 +1,6 @@
 controller_list:
   - name: fake_manipulator_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - prbt_joint_1
       - prbt_joint_2

--- a/prbt_moveit_config/launch/default_warehouse_db.launch
+++ b/prbt_moveit_config/launch/default_warehouse_db.launch
@@ -5,7 +5,7 @@
   <arg name="moveit_warehouse_database_path" default="$(find moveit_resources_prbt_moveit_config)/default_warehouse_mongo_db" />
 
   <!-- Launch the warehouse with the configured database location -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="$(arg moveit_warehouse_database_path)" />
   </include>
 

--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -25,12 +25,12 @@
   <arg name="use_gui" default="false" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- If needed, broadcast static tf for robot root -->
-  
+
 
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
@@ -42,7 +42,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
   <!-- Run the main MoveIt! executable without trajectory execution (we do not have controllers configured by default) -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="execution_type" value="$(arg execution_type)"/>
@@ -52,13 +52,13 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/moveit_rviz.launch">
-    <arg name="rviz_config" value="$(find moveit_resources_prbt_moveit_config)/launch/moveit.rviz"/>
+  <include file="$(dirname)/moveit_rviz.launch">
+    <arg name="rviz_config" value="$(dirname)/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
   <!-- If database loading was enabled, start mongodb as well -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/default_warehouse_db.launch" if="$(arg db)">
+  <include file="$(dirname)/default_warehouse_db.launch" if="$(arg db)">
     <arg name="moveit_warehouse_database_path" value="$(arg db_path)"/>
   </include>
 

--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -12,7 +12,7 @@
   <arg name="debug" default="false" />
 
   <!-- Set execution mode for fake execution controllers -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!--
   By default, hide joint_state_publisher's GUI
@@ -45,7 +45,7 @@
   <include file="$(dirname)/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
-    <arg name="execution_type" value="$(arg execution_type)"/>
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>

--- a/prbt_moveit_config/launch/fake_moveit_controller_manager.launch.xml
+++ b/prbt_moveit_config/launch/fake_moveit_controller_manager.launch.xml
@@ -3,7 +3,7 @@
   <arg name="gripper" default="" />
 
   <!-- execute the trajectory in 'interpolate' mode or jump to goal position in 'last point' mode -->
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- Set the param that trajectory_execution_manager needs to find the controller plugin -->
   <param name="moveit_controller_manager" value="moveit_fake_controller_manager/MoveItFakeControllerManager"/>

--- a/prbt_moveit_config/launch/move_group.launch
+++ b/prbt_moveit_config/launch/move_group.launch
@@ -6,8 +6,7 @@
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
-  <arg     if="$(arg debug)" name="launch_prefix"
-	   value="gdb -x $(find moveit_resources_prbt_moveit_config)/launch/gdb_settings.gdb --ex run --args" />
+  <arg if="$(arg debug)" name="launch_prefix" value="gdb -x $(dirname)/gdb_settings.gdb --ex run --args" />
 
   <!-- Verbose Mode Option -->
   <arg name="info" default="$(arg debug)" />
@@ -29,7 +28,7 @@
   <arg name="gripper" default="" />
 
   <!-- load robot models -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/planning_context.launch" >
+  <include file="$(dirname)/planning_context.launch">
     <arg name="gripper" value="$(arg gripper)" />
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
   </include>
@@ -38,25 +37,24 @@
   <group ns="move_group/planning_pipelines">
 
     <!-- OMPL -->
-    <include ns="ompl" file="$(find moveit_resources_prbt_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="ompl" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="ompl" />
     </include>
 
     <!-- Pilz Industrial Motion-->
-    <include ns="pilz_industrial_motion_planner" file="$(find moveit_resources_prbt_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include ns="pilz_industrial_motion_planner" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="pilz_industrial_motion_planner" />
     </include>
 
     <!-- Load non-default planner if passed as parameter -->
-    <include if="$(eval arg('pipeline') not in ['ompl', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)"
-             file="$(find moveit_resources_prbt_moveit_config)/launch/planning_pipeline.launch.xml">
+    <include if="$(eval arg('pipeline') not in ['ompl', 'pilz_industrial_motion_planner'])" ns="$(arg pipeline)" file="$(dirname)/planning_pipeline.launch.xml">
       <arg name="pipeline" value="$(arg pipeline)" />
     </include>
 
   </group>
 
   <!-- Trajectory Execution Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_prbt_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)" />
     <arg name="moveit_controller_manager" value="prbt" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
@@ -65,7 +63,7 @@
   </include>
 
   <!-- Sensors Functionality -->
-  <include ns="move_group" file="$(find moveit_resources_prbt_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
+  <include ns="move_group" file="$(dirname)/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_sensor_manager" value="prbt" />
   </include>
 

--- a/prbt_moveit_config/launch/move_group.launch
+++ b/prbt_moveit_config/launch/move_group.launch
@@ -16,7 +16,7 @@
   <!-- move_group settings -->
   <arg name="allow_trajectory_execution" default="true"/>
   <arg name="fake_execution" default="false"/>
-  <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
+  <arg name="fake_execution_type" default="interpolate" /> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
@@ -59,7 +59,7 @@
     <arg name="moveit_controller_manager" value="prbt" unless="$(arg fake_execution)"/>
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
     <arg name="gripper" value="$(arg gripper)" />
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
   <!-- Sensors Functionality -->

--- a/prbt_moveit_config/launch/moveit_planning_execution.launch
+++ b/prbt_moveit_config/launch/moveit_planning_execution.launch
@@ -38,7 +38,7 @@ limitations under the License.
 
   <!-- Start RViz with default configuration settings. Once you have changed the configuration and have saved
        it inside your package folder, set the path and file name here. -->
-  <arg name="rviz_config" default="$(find moveit_resources_prbt_moveit_config)/launch/moveit.rviz" />
+  <arg name="rviz_config" default="$(dirname)/moveit.rviz" />
 
   <!-- configuration for moveit -->
   <arg name="pipeline" default="ompl" /><!-- Choose planning pipeline -->
@@ -46,7 +46,7 @@ limitations under the License.
   <arg name="disable_capabilities" default=""/> <!-- inhibit capabilites (space seperated) -->
 
   <!-- load the robot_description parameter before launching ROS-I nodes -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/planning_context.launch" >
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />
     <arg name="gripper" value="$(arg gripper)" />
   </include>
@@ -76,7 +76,7 @@ limitations under the License.
     </include>
   </group>
 
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/move_group.launch">
+  <include file="$(dirname)/move_group.launch">
     <arg name="publish_monitored_planning_scene" value="true" />
     <arg name="fake_execution" value="$(arg sim)"/>
     <arg name="pipeline" value="$(arg pipeline)" />
@@ -86,7 +86,7 @@ limitations under the License.
     <arg name="disable_capabilities" value="$(arg disable_capabilities)" />
   </include>
 
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/moveit_rviz.launch">
+  <include file="$(dirname)/moveit_rviz.launch">
     <arg name="rviz_config" value="$(arg rviz_config)"/>
   </include>
 

--- a/prbt_moveit_config/launch/planning_context.launch
+++ b/prbt_moveit_config/launch/planning_context.launch
@@ -11,13 +11,13 @@
   <!-- Load universal robot description format (URDF) -->
   <param  if="$(arg load_robot_description)"
           name="$(arg robot_description)"
-          command="$(find xacro)/xacro --inorder $(find moveit_resources_prbt_support)/urdf/prbt.xacro
+          command="$(find xacro)/xacro $(find moveit_resources_prbt_support)/urdf/prbt.xacro
                   gripper:=$(arg gripper)"/>
 
   <!-- The semantic description that corresponds to the URDF -->
-  <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro --inorder
+  <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro
   $(find moveit_resources_prbt_moveit_config)/config/prbt.srdf.xacro gripper:=$(arg gripper)" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam if="$(eval not gripper)" command="load" file="$(find moveit_resources_prbt_moveit_config)/config/joint_limits.yaml"/>
@@ -34,5 +34,5 @@
   <group ns="$(arg robot_description)_kinematics">
     <rosparam command="load" file="$(find moveit_resources_prbt_moveit_config)/config/kinematics.yaml"/>
   </group>
-  
+
 </launch>

--- a/prbt_moveit_config/launch/planning_pipeline.launch.xml
+++ b/prbt_moveit_config/launch/planning_pipeline.launch.xml
@@ -1,10 +1,10 @@
 <launch>
 
-  <!-- This file makes it easy to include different planning pipelines; 
-       It is assumed that all planning pipelines are named XXX_planning_pipeline.launch  -->  
+  <!-- This file makes it easy to include different planning pipelines;
+       It is assumed that all planning pipelines are named XXX_planning_pipeline.launch  -->
 
   <arg name="pipeline" default="ompl" />
 
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/$(arg pipeline)_planning_pipeline.launch.xml" />
+  <include file="$(dirname)/$(arg pipeline)_planning_pipeline.launch.xml" />
 
 </launch>

--- a/prbt_moveit_config/launch/run_benchmark_ompl.launch
+++ b/prbt_moveit_config/launch/run_benchmark_ompl.launch
@@ -4,14 +4,14 @@
   <arg name="cfg" />
 
   <!-- Load URDF -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/planning_context.launch">
+  <include file="$(dirname)/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
   <!-- Start the database -->
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/warehouse.launch">
+  <include file="$(dirname)/warehouse.launch">
     <arg name="moveit_warehouse_database_path" value="moveit_ompl_benchmark_warehouse"/>
-  </include>  
+  </include>
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">

--- a/prbt_moveit_config/launch/sensor_manager.launch.xml
+++ b/prbt_moveit_config/launch/sensor_manager.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <!-- This file makes it easy to include the settings for sensor managers -->  
+  <!-- This file makes it easy to include the settings for sensor managers -->
 
   <!-- Params for the octomap monitor -->
   <!--  <param name="octomap_frame" type="string" value="some frame in which the robot moves" /> -->
@@ -9,6 +9,6 @@
 
   <!-- Load the robot specific sensor manager; this sets the moveit_sensor_manager ROS parameter -->
   <arg name="moveit_sensor_manager" default="prbt" />
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
-  
+  <include file="$(dirname)/$(arg moveit_sensor_manager)_moveit_sensor_manager.launch.xml" />
+
 </launch>

--- a/prbt_moveit_config/launch/test_environment.launch
+++ b/prbt_moveit_config/launch/test_environment.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="gripper" default="" />
   <arg name="pipeline" default="pilz_industrial_motion_planner" />
-  <arg name="execution_type" default="last point" />
+  <arg name="fake_execution_type" default="last point" />
 
   <include file="$(dirname)/demo.launch" pass_all_args="true">
     <arg name="use_gui" value="false" />

--- a/prbt_moveit_config/launch/test_environment.launch
+++ b/prbt_moveit_config/launch/test_environment.launch
@@ -1,6 +1,7 @@
 <launch>
-  <arg name="pipeline" />
-  <arg name="fake_execution_type" />
+  <arg name="gripper" default="" />
+  <arg name="pipeline" default="pilz_industrial_motion_planner" />
+  <arg name="execution_type" default="last point" />
 
   <include file="$(dirname)/demo.launch" pass_all_args="true">
     <arg name="use_gui" value="false" />

--- a/prbt_moveit_config/launch/trajectory_execution.launch.xml
+++ b/prbt_moveit_config/launch/trajectory_execution.launch.xml
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="gripper" default="" />
-  <arg name="execution_type" default="interpolate" />
+  <arg name="fake_execution_type" default="interpolate" />
 
   <!-- This file makes it easy to include the settings for trajectory execution  -->
 
@@ -20,7 +20,7 @@
   <arg name="moveit_controller_manager" default="prbt" />
   <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="gripper" value="$(arg gripper)" />
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="fake_execution_type" value="$(arg fake_execution_type)" />
   </include>
 
 </launch>

--- a/prbt_moveit_config/launch/trajectory_execution.launch.xml
+++ b/prbt_moveit_config/launch/trajectory_execution.launch.xml
@@ -3,7 +3,7 @@
   <arg name="gripper" default="" />
   <arg name="execution_type" default="interpolate" />
 
-  <!-- This file makes it easy to include the settings for trajectory execution  -->  
+  <!-- This file makes it easy to include the settings for trajectory execution  -->
 
   <!-- Flag indicating whether MoveIt! is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>
@@ -15,12 +15,12 @@
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
-  
+
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="prbt" />
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
+  <include file="$(dirname)/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
     <arg name="gripper" value="$(arg gripper)" />
     <arg name="execution_type" value="$(arg execution_type)" />
   </include>
-  
+
 </launch>

--- a/prbt_moveit_config/launch/warehouse.launch
+++ b/prbt_moveit_config/launch/warehouse.launch
@@ -1,10 +1,10 @@
 <launch>
-  
+
   <!-- The path to the database must be specified -->
   <arg name="moveit_warehouse_database_path" />
 
-  <!-- Load warehouse parameters -->  
-  <include file="$(find moveit_resources_prbt_moveit_config)/launch/warehouse_settings.launch.xml" />
+  <!-- Load warehouse parameters -->
+  <include file="$(dirname)/warehouse_settings.launch.xml" />
 
   <!-- Run the DB server -->
   <node name="$(anon mongo_wrapper_ros)" cwd="ROS_HOME" type="mongo_wrapper_ros.py" pkg="warehouse_ros_mongo">

--- a/prbt_pg70_support/config/fake_controllers.yaml
+++ b/prbt_pg70_support/config/fake_controllers.yaml
@@ -15,7 +15,7 @@
 
 controller_list:
   - name: fake_manipulator_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - prbt_joint_1
       - prbt_joint_2
@@ -24,6 +24,6 @@ controller_list:
       - prbt_joint_5
       - prbt_joint_6
   - name: fake_gripper_controller
-    type: $(arg execution_type)
+    type: $(arg fake_execution_type)
     joints:
       - prbt_gripper_finger_left_joint


### PR DESCRIPTION
- Introduce `prbt_moveit_config/launch/test_environment.launch`
- Replace `$(find moveit_resources_*_moveit_config)/launch/*` -> `$(dirname)/*`
- Rename launch parameter `execution_type` -> `fake_execution_type`
- Remove deprecated xacro `--inorder` flag

Goes in line with https://github.com/ros-planning/moveit/pull/2932!