### PR TITLE
Fix PRBT's test_environment.launch

### DIFF
--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -3,6 +3,9 @@
   <!-- specify the planning pipeline -->
   <arg name="pipeline" default="ompl" />
 
+  <!-- Choose gripper -->
+  <arg name="gripper" default="" />
+
   <!-- By default, we do not start a database (it can be large) -->
   <arg name="db" default="false" />
   <!-- Allow user to specify database location -->
@@ -50,6 +53,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="pipeline" value="$(arg pipeline)"/>
+    <arg name="gripper" value="$(arg gripper)" />
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->

--- a/prbt_moveit_config/launch/demo.launch
+++ b/prbt_moveit_config/launch/demo.launch
@@ -23,6 +23,7 @@
   This corresponds to moving around the real robot without the use of MoveIt.
   -->
   <arg name="use_gui" default="false" />
+  <arg name="use_rviz" default="true" />
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
   <include file="$(dirname)/planning_context.launch">
@@ -52,7 +53,7 @@
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->
-  <include file="$(dirname)/moveit_rviz.launch">
+  <include file="$(dirname)/moveit_rviz.launch" if="$(arg use_rviz)">
     <arg name="rviz_config" value="$(dirname)/moveit.rviz"/>
     <arg name="debug" value="$(arg debug)"/>
   </include>

--- a/prbt_moveit_config/launch/move_group.launch
+++ b/prbt_moveit_config/launch/move_group.launch
@@ -24,7 +24,7 @@
   <arg name="capabilities" default=""/> <!-- define capabilites that are loaded on start (space seperated) -->
   <arg name="disable_capabilities" default=""/> <!-- inhibit capabilites (space seperated) -->
 
-  <!-- Enable/Disable gripper -->
+  <!-- Choose gripper -->
   <arg name="gripper" default="" />
 
   <!-- load robot models -->


### PR DESCRIPTION
- Introduce `use_rviz` argument to avoid starting rviz
- Forward `gripper` argument through `demo.launch` to `move_group.launch`

Fixes 9c75ca59edb97b2d83d03acf9d38e977ff3a9b74