### PR TITLE
Add exec-dependency on OMPL

### DIFF
--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -31,6 +31,7 @@
   -->
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <!-- TODO(#40): Package not available in ROS 2, find equivalent when migrating launch files


### PR DESCRIPTION
While working on an [integration test ](https://github.com/ros-planning/moveit2/pull/813/commits/3e7ba5530199f681005403fffb754c080f71244f#diff-81840030b4e7339089ca133e47b6b2d76c7941a7f06f8f00d2d83b5beef690ee) for a simulation using the Panda, I had to add `<test_depend>moveit_planners_ompl</test_depend>`. I don't think I should have to do that -- it should be here.

The only thing I'm not sure on is if this would introduce a circular dependency, like the other packages that are commented.