### PR TITLE
Fix PBRT packages build on Windows

### DIFF
--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -4,10 +4,12 @@ project(moveit_resources_prbt_ikfast_manipulator_plugin)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options(-Wall)
-add_compile_options(-Wextra)
-add_compile_options(-Wno-unused-parameter)
-add_compile_options(-Wno-unused-variable)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall)
+  add_compile_options(-Wextra)
+  add_compile_options(-Wno-unused-parameter)
+  add_compile_options(-Wno-unused-variable)
+endif()
 
 # enable aligned new in gcc7+
 if(CMAKE_COMPILER_IS_GNUCXX)
@@ -30,7 +32,11 @@ include_directories(include)
 add_library(prbt_manipulator_moveit_ikfast_plugin SHARED
   src/prbt_manipulator_ikfast_moveit_plugin.cpp)
 # suppress warnings about unused variables in OpenRave's solver code
-target_compile_options(prbt_manipulator_moveit_ikfast_plugin PRIVATE -Wno-unused-variable)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(prbt_manipulator_moveit_ikfast_plugin PRIVATE -Wno-unused-variable)
+elseif(MSVC)
+  target_compile_definitions(prbt_manipulator_moveit_ikfast_plugin PRIVATE _USE_MATH_DEFINES)
+endif()
 ament_target_dependencies(prbt_manipulator_moveit_ikfast_plugin
   moveit_core
   pluginlib

--- a/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
+++ b/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_moveit_plugin.cpp
@@ -805,8 +805,12 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_
     RCLCPP_ERROR(LOGGER, "Unexpected number of joint angles");
     return false;
   }
-
+#ifdef _MSC_VER
+  std::vector<IkReal> anglesVec(num_joints_);
+  IkReal* angles = anglesVec.data();
+#else
   IkReal angles[num_joints_];
+#endif
   for (unsigned char i = 0; i < num_joints_; i++)
     angles[i] = joint_angles[i];
 

--- a/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_solver.cpp
+++ b/prbt_ikfast_manipulator_plugin/src/prbt_manipulator_ikfast_solver.cpp
@@ -27,7 +27,7 @@ using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
 #define IKFAST_COMPILE_ASSERT(x) extern int __dummy[(int)x]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==0x1000004a);
+IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 
 #include <cmath>
 #include <vector>


### PR DESCRIPTION
Here's a summary of the changes I made to get this building on Windows again:
- The PBRT packages use compiler flags which aren't available on MSVC, so I added checks before using them.
- In order to use `M_PI`, `_USE_MATH_DEFINES` needs to be defined.
- Variable-length arrays aren't supported on MSVC, so I use a vector instead.
- The check to verify the IKFast version always fails. However, because variable-length arrays work on GCC, it's possible to create an array of size 0 and the assert doesn't actually fail. However, on MSVC, because variable-length arrays are not supported, an error is thrown. To fix the version check, I changed the version compared to `61`, which is what I found in `ikfast.h`