### PR TITLE
Add build guard for prbt ikfast plugin

### DIFF
--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -17,7 +17,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(moveit_core REQUIRED)
+find_package(moveit_core QUIET)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2_kdl REQUIRED)
@@ -25,13 +25,8 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_eigen_kdl REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
-include_directories(include)
-
-add_library(prbt_manipulator_moveit_ikfast_plugin SHARED
-  src/prbt_manipulator_ikfast_moveit_plugin.cpp)
-# suppress warnings about unused variables in OpenRave's solver code
-target_compile_options(prbt_manipulator_moveit_ikfast_plugin PRIVATE -Wno-unused-variable)
-ament_target_dependencies(prbt_manipulator_moveit_ikfast_plugin
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  ament_cmake
   moveit_core
   pluginlib
   rclcpp
@@ -41,18 +36,29 @@ ament_target_dependencies(prbt_manipulator_moveit_ikfast_plugin
   tf2_geometry_msgs
 )
 
-pluginlib_export_plugin_description_file(moveit_core prbt_manipulator_moveit_ikfast_plugin_description.xml)
+include_directories(include)
 
-install(
-  TARGETS prbt_manipulator_moveit_ikfast_plugin
-  EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
+if(moveit_core)
+  add_library(prbt_manipulator_moveit_ikfast_plugin SHARED
+    src/prbt_manipulator_ikfast_moveit_plugin.cpp)
+  # suppress warnings about unused variables in OpenRave's solver code
+  target_compile_options(prbt_manipulator_moveit_ikfast_plugin PRIVATE -Wno-unused-variable)
+  ament_target_dependencies(prbt_manipulator_moveit_ikfast_plugin
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+  )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+  pluginlib_export_plugin_description_file(moveit_core prbt_manipulator_moveit_ikfast_plugin_description.xml)
+
+  install(
+    TARGETS prbt_manipulator_moveit_ikfast_plugin
+    EXPORT export_${PROJECT_NAME}
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+  )
+  ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+  ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+endif()
 
 ament_package()


### PR DESCRIPTION
Adds build guard for prbt ikfast plugin in an attempt to resolve hack fixes in MoveIt2 CI and fix docker builds.

Also fixes a small export issue.