### PR TITLE
Do not define Panda initial velocities

### DIFF
--- a/panda_moveit_config/config/initial_positions.yaml
+++ b/panda_moveit_config/config/initial_positions.yaml
@@ -7,11 +7,3 @@ initial_positions:
   panda_joint5: 0.0
   panda_joint6: 1.571
   panda_joint7: 0.785
-initial_velocities:
-  panda_joint1: 0.0
-  panda_joint2: 0.0
-  panda_joint3: 0.0
-  panda_joint4: 0.0
-  panda_joint5: 0.0
-  panda_joint6: 0.0
-  panda_joint7: 0.0

--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -3,7 +3,6 @@
 
     <xacro:macro name="panda_ros2_control" params="name initial_positions_file">
         <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
-        <xacro:property name="initial_velocities" value="${load_yaml(initial_positions_file)['initial_velocities']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>
@@ -14,63 +13,49 @@
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint1']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint1']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint2">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint2']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint2']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint3">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint3']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint3']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint4">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint4']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint4']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint5">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint5']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint5']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint6">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint6']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint6']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_joint7">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint7']}</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">${initial_velocities['panda_joint7']}</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -11,9 +11,7 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="panda_finger_joint2">
                 <param name="mimic">panda_finger_joint1</param>
@@ -22,9 +20,7 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity">
-                  <param name="initial_value">0.0</param>
-                </state_interface>
+                <state_interface name="velocity"/>
             </joint>
         </ros2_control>
     </xacro:macro>


### PR DESCRIPTION
This is a temporary fix to get CI passing. See the conversation here:

https://github.com/ros-planning/moveit2/pull/980#issuecomment-1019389113