### PR TITLE
Use Panda joint_limits.yaml

### DIFF
--- a/panda_moveit_config/config/joint_limits.yaml
+++ b/panda_moveit_config/config/joint_limits.yaml
@@ -7,49 +7,64 @@
 # to max accel in 1 ms) the acceleration limits are the ones that satisfy
 # max_jerk = (max_acceleration - min_acceleration) / 0.001
 
-joint_limits:
-  panda_joint1:
-    has_velocity_limits: true
-    max_velocity: 2.1750
-    has_acceleration_limits: true
-    max_acceleration: 3.75
-  panda_joint2:
-    has_velocity_limits: true
-    max_velocity: 2.1750
-    has_acceleration_limits: true
-    max_acceleration: 1.875
-  panda_joint3:
-    has_velocity_limits: true
-    max_velocity: 2.1750
-    has_acceleration_limits: true
-    max_acceleration: 2.5
-  panda_joint4:
-    has_velocity_limits: true
-    max_velocity: 2.1750
-    has_acceleration_limits: true
-    max_acceleration: 3.125
-  panda_joint5:
-    has_velocity_limits: true
-    max_velocity: 2.6100
-    has_acceleration_limits: true
-    max_acceleration: 3.75
-  panda_joint6:
-    has_velocity_limits: true
-    max_velocity: 2.6100
-    has_acceleration_limits: true
-    max_acceleration: 5.0
-  panda_joint7:
-    has_velocity_limits: true
-    max_velocity: 2.6100
-    has_acceleration_limits: true
-    max_acceleration: 5.0
-  panda_finger_joint1:
-    has_velocity_limits: true
-    max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0.0
-  panda_finger_joint2:
-    has_velocity_limits: true
-    max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0.0
+robot_description_planning:
+  joint_limits:
+    panda_joint1:
+      has_velocity_limits: true
+      max_velocity: 2.1750
+      has_acceleration_limits: true
+      max_acceleration: 3.75
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint2:
+      has_velocity_limits: true
+      max_velocity: 2.1750
+      has_acceleration_limits: true
+      max_acceleration: 1.875
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint3:
+      has_velocity_limits: true
+      max_velocity: 2.1750
+      has_acceleration_limits: true
+      max_acceleration: 2.5
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint4:
+      has_velocity_limits: true
+      max_velocity: 2.1750
+      has_acceleration_limits: true
+      max_acceleration: 3.125
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint5:
+      has_velocity_limits: true
+      max_velocity: 2.6100
+      has_acceleration_limits: true
+      max_acceleration: 3.75
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint6:
+      has_velocity_limits: true
+      max_velocity: 2.6100
+      has_acceleration_limits: true
+      max_acceleration: 5.0
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_joint7:
+      has_velocity_limits: true
+      max_velocity: 2.6100
+      has_acceleration_limits: true
+      max_acceleration: 5.0
+      has_jerk_limits: true
+      max_jerk: 500.0
+    panda_finger_joint1:
+      has_velocity_limits: true
+      max_velocity: 0.1
+      has_acceleration_limits: false
+      max_acceleration: 0.0
+    panda_finger_joint2:
+      has_velocity_limits: true
+      max_velocity: 0.1
+      has_acceleration_limits: false
+      max_acceleration: 0.0

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -59,7 +59,10 @@ def generate_launch_description():
     robot_description_semantic = {
         "robot_description_semantic": robot_description_semantic_config
     }
-
+    # joint_limits.yaml is optional. It overrides limits in the URDF
+    joint_limits_yaml = load_yaml(
+        "moveit_resources_panda_moveit_config", "config/joint_limits.yaml"
+    )
     kinematics_yaml = load_yaml(
         "moveit_resources_panda_moveit_config", "config/kinematics.yaml"
     )
@@ -108,6 +111,7 @@ def generate_launch_description():
         parameters=[
             robot_description,
             robot_description_semantic,
+            joint_limits_yaml,
             kinematics_yaml,
             ompl_planning_pipeline_config,
             trajectory_execution,


### PR DESCRIPTION
Add the namespace to these parameters so they're loaded properly. You can see that the namespace is needed here:

https://github.com/ros-planning/moveit2/blob/d59a46372c5a3c088a61732f5c8f152f67778c34/moveit_ros/planning/robot_model_loader/src/robot_model_loader.cpp#L124

joint_limits.yaml is optional. It overrides values in the URDF in case you want custom limits for your robot. It also allows a jerk limit to be specified, which you cannot do from the URDF.

Fixes #122 