### PR TITLE
Fix controller_manager node's output type

### DIFF
--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -100,10 +100,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[moveit_config.robot_description, ros2_controllers_path],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="screen",
     )
 
     # Load controllers


### PR DESCRIPTION
 Fix the following error when launching `demo.launch.py`

`Caught exception in launch (see debug for traceback): stdoutstderr is not a valid standard output config i.e. "screen", "log" or "both"`
