### PR TITLE
Switch output from {stdout, stderr} to both

### DIFF
--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -100,10 +100,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[moveit_config.robot_description, ros2_controllers_path],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="both",
     )
 
     # Load controllers


### PR DESCRIPTION
Fixes the following error 

```[ERROR] [launch]: Caught exception in launch (see debug for traceback): stdoutstderr is not a valid standard output config i.e. "screen", "log" or "both"```

when trying to launch the demo with

``` ros2 launch moveit_task_constructor_demo demo.launch.py```