### PR TITLE
Proper scoping for controllers in Panda Config

### DIFF
--- a/panda_moveit_config/config/moveit_controllers.yaml
+++ b/panda_moveit_config/config/moveit_controllers.yaml
@@ -6,18 +6,19 @@ trajectory_execution:
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 
-controller_names:
-  - panda_arm_controller
+moveit_simple_controller_manager:
+  controller_names:
+    - panda_arm_controller
 
-panda_arm_controller:
-  action_ns: follow_joint_trajectory
-  type: FollowJointTrajectory
-  default: true
-  joints:
-    - panda_joint1
-    - panda_joint2
-    - panda_joint3
-    - panda_joint4
-    - panda_joint5
-    - panda_joint6
-    - panda_joint7
+  panda_arm_controller:
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7


### PR DESCRIPTION
`moveit_controllers.yaml` is inconsistent with `gripper_moveit_controllers.yaml`, which ihas the controller_names and declarations within the `moveit_simple_controller_manager` namespace. 