### PR TITLE
Explicitly use CHOMP and OMPL planners

### DIFF
--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -25,6 +25,7 @@ def generate_launch_description():
         .robot_description(file_path="config/panda.urdf.xacro")
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
+        .planning_pipelines("ompl", ["ompl", "chomp", "pilz_industrial_motion_planner"])
         .to_moveit_configs()
     )
 

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
         .robot_description(file_path="config/panda.urdf.xacro")
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
-        .planning_pipelines("ompl", ["ompl", "chomp", "pilz_industrial_motion_planner"])
+        .planning_pipelines(pipelines=["ompl", "chomp"])
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
Explicitly use CHOMP, OMPL, and Pilz as planners rather than iterating through all `*_planning.yaml` files, some of which do not work as of now.

Partially resolves #134