### PR TITLE
Remove fanuc's invalid sensor config

### DIFF
--- a/fanuc_moveit_config/config/sensors_3d.yaml
+++ b/fanuc_moveit_config/config/sensors_3d.yaml
@@ -1,3 +1,2 @@
 # The name of this file shouldn't be changed, or else the Setup Assistant won't detect it
-sensors:
-  - {}
+sensors: []


### PR DESCRIPTION
This is causing problems for https://github.com/ros-planning/moveit2/pull/1387 and has been bugging me for awhile. 