### PR TITLE
Rename cartesian_limits.yaml -> pilz_cartesian_limits.yaml

### DIFF
--- a/fanuc_moveit_config/config/pilz_cartesian_limits.yaml
+++ b/fanuc_moveit_config/config/pilz_cartesian_limits.yaml
@@ -1,3 +1,4 @@
+# Cartesian limits for the Pilz planner
 cartesian_limits:
   max_trans_vel: 1.0
   max_trans_acc: 2.25

--- a/panda_moveit_config/config/pilz_cartesian_limits.yaml
+++ b/panda_moveit_config/config/pilz_cartesian_limits.yaml
@@ -1,3 +1,4 @@
+# Cartesian limits for the Pilz planner
 cartesian_limits:
   max_trans_vel: 1.0
   max_trans_acc: 2.25


### PR DESCRIPTION
I think it makes sense to specify this is only for Pilz. [Users were getting confused](https://answers.ros.org/question/403542/set-cartesian-limits-with-moveit/).

Merge with https://github.com/ros-planning/moveit2/pull/1422