### PR TITLE
Fix dependencies for panda dual arm environment

### DIFF
--- a/dual_panda_moveit_config/package.xml
+++ b/dual_panda_moveit_config/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- disabled to remove circular dependencies
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
@@ -23,6 +24,7 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>moveit_simple_controller_manager</run_depend>
+  -->
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>


### PR DESCRIPTION
Disabling run dependencies to avoid circular dependencies error, same as the panda_moveit_config package.