### PR TITLE
Remove build jobs for Foxy, Galactic

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -15,12 +15,8 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: foxy, ROS_REPO: main}
-          - {ROS_DISTRO: foxy, ROS_REPO: testing}
           - {ROS_DISTRO: rolling, ROS_REPO: main}
           - {ROS_DISTRO: rolling, ROS_REPO: testing}
-          - {ROS_DISTRO: galactic, ROS_REPO: main}
-          - {ROS_DISTRO: galactic, ROS_REPO: testing}
           - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: humble, ROS_REPO: testing}
 


### PR DESCRIPTION
Foxy and Galactic are not really supported in combination with the MoveIt 2 distro branches. We now have dedicated branches `foxy` and `galactic` that match the released versions and that should be used by anyone who wants to build older distros from source.