### PR TITLE
Add Pilz to panda launch

### DIFF
--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -25,7 +25,9 @@ def generate_launch_description():
         .robot_description(file_path="config/panda.urdf.xacro")
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
-        .planning_pipelines(pipelines=["ompl", "chomp"])
+        .planning_pipelines(
+            pipelines=["ompl", "chomp", "pilz_industrial_motion_planner"]
+        )
         .to_moveit_configs()
     )
 


### PR DESCRIPTION
In #135, Pilz was removed from the launch file due to some issues with it. These have since been resolved (https://github.com/ros-planning/moveit2/pull/1281), so this PR adds Pilz back to the panda launch file.