### PR TITLE
[ROS-O] do not enforce "old" standard

### DIFF
--- a/prbt_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/prbt_ikfast_manipulator_plugin/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.1.3)
 project(moveit_resources_prbt_ikfast_manipulator_plugin)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 if(NOT MSVC)
   add_compile_options(-Wall)
   add_compile_options(-Wextra)


### PR DESCRIPTION
C++14 is default in clang/gcc anyway
and new log4cxx requires C++17.

It's better not to declare it at all and leave the choice to the system environment.

required for ROS-O.