### PR TITLE
Removed warning about using deprecated load_yaml method.

### DIFF
--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="panda_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>
@@ -60,3 +60,4 @@
         </ros2_control>
     </xacro:macro>
 </robot>
+

--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -60,4 +60,3 @@
         </ros2_control>
     </xacro:macro>
 </robot>
-


### PR DESCRIPTION
When running the following command, a warning was displayed suggesting to use `xacro.load_yaml` instead of `load_yaml`.

`ros2 launch moveit_task_constructor_demo demo.launch.py`

The first method is now used instead of the second one.