### PR TITLE
[ROS2]: Add a new parameter to panda's xacro to select ros2_control hardware interface type

### DIFF
--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -1,12 +1,19 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="panda_ros2_control" params="name initial_positions_file">
+    <xacro:macro name="panda_ros2_control" params="name initial_positions_file ros2_control_hardware_type">
         <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>
-                <plugin>mock_components/GenericSystem</plugin>
+                <xacro:if value="${ros2_control_hardware_type == 'mock_components'}">
+                    <plugin>mock_components/GenericSystem</plugin>
+                </xacro:if>
+                <xacro:if value="${ros2_control_hardware_type == 'isaac'}">
+                    <plugin>isaac_ros2_control/IsaacSystem</plugin>
+                    <param name="joint_commands_topic">/isaac_joint_commands</param>
+                    <param name="joint_states_topic">/isaac_joint_states</param>
+                </xacro:if>
             </hardware>
             <joint name="panda_joint1">
                 <command_interface name="position"/>

--- a/panda_moveit_config/config/panda.urdf.xacro
+++ b/panda_moveit_config/config/panda.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
     <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
+    <xacro:arg name="ros2_control_hardware_type" default="mock_components" />
 
     <!-- Import panda urdf file -->
     <xacro:include filename="$(find moveit_resources_panda_description)/urdf/panda.urdf" />
@@ -9,6 +10,6 @@
     <xacro:include filename="panda.ros2_control.xacro" />
     <xacro:include filename="panda_hand.ros2_control.xacro" />
 
-    <xacro:panda_ros2_control name="PandaFakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
-    <xacro:panda_hand_ros2_control name="PandaHandFakeSystem"/>
+    <xacro:panda_ros2_control name="PandaFakeSystem" initial_positions_file="$(arg initial_positions_file)" ros2_control_hardware_type="$(arg ros2_control_hardware_type)"/>
+    <xacro:panda_hand_ros2_control name="PandaHandFakeSystem" ros2_control_hardware_type="$(arg ros2_control_hardware_type)"/>
 </robot>

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -1,10 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <xacro:macro name="panda_hand_ros2_control" params="name">
+    <xacro:macro name="panda_hand_ros2_control" params="name ros2_control_hardware_type">
         <ros2_control name="${name}" type="system">
             <hardware>
-                <plugin>mock_components/GenericSystem</plugin>
+                <xacro:if value="${ros2_control_hardware_type == 'mock_components'}">
+                    <plugin>mock_components/GenericSystem</plugin>
+                </xacro:if>
+                <xacro:if value="${ros2_control_hardware_type == 'isaac'}">
+                    <plugin>isaac_ros2_control/IsaacSystem</plugin>
+                    <param name="joint_commands_topic">/isaac_joint_commands</param>
+                    <param name="joint_states_topic">/isaac_joint_states</param>
+                </xacro:if>
             </hardware>
             <joint name="panda_finger_joint1">
                 <command_interface name="position" />

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -20,9 +20,22 @@ def generate_launch_description():
         "db", default_value="False", description="Database flag"
     )
 
+    ros2_control_hardware_type = DeclareLaunchArgument(
+        "ros2_control_hardware_type",
+        default_value="mock_components",
+        description="ROS2 control hardware interface type to use for the launch file -- possible values: [mock_components, isaac]",
+    )
+
     moveit_config = (
         MoveItConfigsBuilder("moveit_resources_panda")
-        .robot_description(file_path="config/panda.urdf.xacro")
+        .robot_description(
+            file_path="config/panda.urdf.xacro",
+            mappings={
+                "ros2_control_hardware_type": LaunchConfiguration(
+                    "ros2_control_hardware_type"
+                )
+            },
+        )
         .robot_description_semantic(file_path="config/panda.srdf")
         .trajectory_execution(file_path="config/gripper_moveit_controllers.yaml")
         .planning_pipelines(

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -160,6 +160,7 @@ def generate_launch_description():
         [
             tutorial_arg,
             db_arg,
+            ros2_control_hardware_type,
             rviz_node,
             rviz_node_tutorial,
             static_tf_node,


### PR DESCRIPTION
This depends on https://github.com/ros-planning/moveit2/pull/1805.

This's needed for a tutorial I'm writing on how to use moveit with isaac through https://github.com/PickNikRobotics/isaac_ros2_control/

I bet we could add gazebo and ignition without any problem, but I didn't test it!

```xml
<xacro:if value="${ros2_control_hardware_type == 'gazebo'}">
  <plugin>gazebo_ros2_control/GazeboSystem</plugin>
</xacro:if>
<xacro:if value="${ros2_control_hardware_type  == 'ignition'}">
  <plugin>ign_ros2_control/IgnitionSystem</plugin>
</xacro:if>
```