### PR TITLE
Pin ubuntu version and update clang-format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   pre-commit:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: Install clang-format-10
-      run: sudo apt-get install clang-format-10
+    - name: Install clang-format-12
+      run: sudo apt-get install clang-format-12
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: Install clang-format-12
-      run: sudo apt-get install clang-format-12
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -24,7 +24,7 @@ jobs:
       CCACHE_DIR: ~/.ccache
 
     name: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,7 +19,7 @@ jobs:
       BASEDIR: ${{ github.workspace }}/.work
 
     name: "${{ matrix.distro }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: industrial_ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-10
+        entry: clang-format-12
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,3 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-
-  - repo: local
-    hooks:
-      - id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat.
-        entry: clang-format-12
-        language: system
-        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
-        args: ['-fallback-style=none', '-i']


### PR DESCRIPTION
Our ros2 branch target humble/rolling and ubuntu 22.04 is the only tier 1 platform. this PR avoid using ubuntu-latest and pin the version + update clang-format to 12  