### PR TITLE
Add execution_duration_monitoring param to the example config

### DIFF
--- a/fanuc_moveit_config/config/moveit_controllers.yaml
+++ b/fanuc_moveit_config/config/moveit_controllers.yaml
@@ -3,6 +3,7 @@ trajectory_execution:
   allowed_execution_duration_scaling: 1.2
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
+  trajectory_duration_monitoring: true
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 

--- a/panda_moveit_config/config/moveit_controllers.yaml
+++ b/panda_moveit_config/config/moveit_controllers.yaml
@@ -3,6 +3,7 @@ trajectory_execution:
   allowed_execution_duration_scaling: 1.2
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
+  trajectory_duration_monitoring: true
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 


### PR DESCRIPTION
Inspired by a user question in this issue:  https://github.com/ros-planning/moveit2/issues/1848

Let's add this to the yaml for better documentation.