### PR TITLE
Add dual arm panda config package from moveit2_tutorials

### DIFF
--- a/dual_arm_panda_moveit_config/CMakeLists.txt
+++ b/dual_arm_panda_moveit_config/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(dual_arm_panda_moveit_config)
+find_package(ament_cmake REQUIRED)
+
+ament_package()
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})

--- a/dual_arm_panda_moveit_config/README.md
+++ b/dual_arm_panda_moveit_config/README.md
@@ -1,0 +1,1 @@
+## Dual Franka Emika Panda MoveIt Configuration

--- a/dual_arm_panda_moveit_config/config/hand.xacro
+++ b/dual_arm_panda_moveit_config/config/hand.xacro
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
+  <xacro:macro name="hand">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="hand">
+      <link name="panda_hand" />
+      <link name="panda_leftfinger" />
+      <link name="panda_rightfinger" />
+      <joint name="panda_finger_joint1" />
+      <passive_joint name="panda_finger_joint2" />
+    </group>
+    <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+    <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="panda_hand" link2="panda_leftfinger" reason="Adjacent" />
+    <disable_collisions link1="panda_hand" link2="panda_rightfinger" reason="Adjacent" />
+    <disable_collisions link1="panda_leftfinger" link2="panda_rightfinger" reason="Default" />
+  </xacro:macro>
+</robot>

--- a/dual_arm_panda_moveit_config/config/joint_limits.yaml
+++ b/dual_arm_panda_moveit_config/config/joint_limits.yaml
@@ -1,0 +1,100 @@
+# joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+# Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
+# Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
+
+# As MoveIt! does not support jerk limits, the acceleration limits provided here are the highest values that guarantee
+# that no jerk limits will be violated. More precisely, applying Euler differentiation in the worst case (from min accel
+# to max accel in 1 ms) the acceleration limits are the ones that satisfy
+# max_jerk = (max_acceleration - min_acceleration) / 0.001
+
+joint_limits:
+  right_panda_joint1:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  right_panda_joint2:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 1.875
+  right_panda_joint3:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 2.5
+  right_panda_joint4:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.125
+  right_panda_joint5:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  right_panda_joint6:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_panda_joint7:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  right_panda_finger_joint1:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  right_panda_finger_joint2:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  left_panda_joint1:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  left_panda_joint2:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 1.875
+  left_panda_joint3:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 2.5
+  left_panda_joint4:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.125
+  left_panda_joint5:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  left_panda_joint6:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_panda_joint7:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  left_panda_finger_joint1:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0.0
+  left_panda_finger_joint2:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0.0

--- a/dual_arm_panda_moveit_config/config/kinematics.yaml
+++ b/dual_arm_panda_moveit_config/config/kinematics.yaml
@@ -1,0 +1,8 @@
+left_panda_arm:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.05
+right_panda_arm:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.05

--- a/dual_arm_panda_moveit_config/config/left_initial_positions.yaml
+++ b/dual_arm_panda_moveit_config/config/left_initial_positions.yaml
@@ -1,0 +1,9 @@
+# Default initial positions for the panda arm's ros2_control fake system
+initial_positions:
+  panda_joint1: 0.0
+  panda_joint2: -0.785
+  panda_joint3: 0.0
+  panda_joint4: -2.356
+  panda_joint5: 0.0
+  panda_joint6: 1.571
+  panda_joint7: 0.785

--- a/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
+++ b/dual_arm_panda_moveit_config/config/moveit_controllers.yaml
@@ -1,0 +1,7 @@
+# MoveIt uses this configuration for controller management
+trajectory_execution:
+  allowed_execution_duration_scaling: 1.2
+  allowed_goal_duration_margin: 0.5
+  allowed_start_tolerance: 0.01
+
+moveit_controller_manager: moveit_ros_control_interface/Ros2ControlManager

--- a/dual_arm_panda_moveit_config/config/ompl_planning.yaml
+++ b/dual_arm_panda_moveit_config/config/ompl_planning.yaml
@@ -1,0 +1,212 @@
+planning_plugin: ompl_interface/OMPLPlanner
+request_adapters: >-
+  default_planner_request_adapters/AddTimeOptimalParameterization
+  default_planner_request_adapters/ResolveConstraintFrames
+  default_planner_request_adapters/FixWorkspaceBounds
+  default_planner_request_adapters/FixStartStateBounds
+  default_planner_request_adapters/FixStartStateCollision
+  default_planner_request_adapters/FixStartStatePathConstraints
+start_state_max_bounds_error: 0.1
+planner_configs:
+  SBLkConfigDefault:
+    type: geometric::SBL
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  ESTkConfigDefault:
+    type: geometric::EST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0 setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+  LBKPIECEkConfigDefault:
+    type: geometric::LBKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  BKPIECEkConfigDefault:
+    type: geometric::BKPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  KPIECEkConfigDefault:
+    type: geometric::KPIECE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    border_fraction: 0.9  # Fraction of time focused on boarder default: 0.9 (0.0,1.]
+    failed_expansion_score_factor: 0.5  # When extending motion fails, scale score by factor. default: 0.5
+    min_valid_path_fraction: 0.5  # Accept partially valid moves above fraction. default: 0.5
+  RRTkConfigDefault:
+    type: geometric::RRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+  RRTConnectkConfigDefault:
+    type: geometric::RRTConnect
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  RRTstarkConfigDefault:
+    type: geometric::RRTstar
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
+  TRRTkConfigDefault:
+    type: geometric::TRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    max_states_failed: 10  # when to start increasing temp. default: 10
+    temp_change_factor: 2.0  # how much to increase or decrease temp. default: 2.0
+    min_temperature: 10e-10  # lower limit of temp change. default: 10e-10
+    init_temperature: 10e-6  # initial temperature. default: 10e-6
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountierNodeRatio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    k_constant: 0.0  # value used to normalize expression. default: 0.0 set in setup()
+  PRMkConfigDefault:
+    type: geometric::PRM
+    max_nearest_neighbors: 10  # use k nearest neighbors. default: 10
+  PRMstarkConfigDefault:
+    type: geometric::PRMstar
+  FMTkConfigDefault:
+    type: geometric::FMT
+    num_samples: 1000  # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.1  # multiplier used for the nearest neighbors search radius. default: 1.1
+    nearest_k: 1  # use Knearest strategy. default: 1
+    cache_cc: 1  # use collision checking cache. default: 1
+    heuristics: 0  # activate cost to go heuristics. default: 0
+    extended_fmt: 1  # activate the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  BFMTkConfigDefault:
+    type: geometric::BFMT
+    num_samples: 1000  # number of states that the planner should sample. default: 1000
+    radius_multiplier: 1.0  # multiplier used for the nearest neighbors search radius. default: 1.0
+    nearest_k: 1  # use the Knearest strategy. default: 1
+    balanced: 0  # exploration strategy: balanced true expands one tree every iteration. False will select the tree with lowest maximum cost to go. default: 1
+    optimality: 1  # termination strategy: optimality true finishes when the best possible path is found. Otherwise, the algorithm will finish when the first feasible path is found. default: 1
+    heuristics: 1  # activates cost to go heuristics. default: 1
+    cache_cc: 1  # use the collision checking cache. default: 1
+    extended_fmt: 1  # Activates the extended FMT*: adding new samples if planner does not finish successfully. default: 1
+  PDSTkConfigDefault:
+    type: geometric::PDST
+  STRIDEkConfigDefault:
+    type: geometric::STRIDE
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    use_projected_distance: 0  # whether nearest neighbors are computed based on distances in a projection of the state rather distances in the state space itself. default: 0
+    degree: 16  # desired degree of a node in the Geometric Near-neightbor Access Tree (GNAT). default: 16
+    max_degree: 18  # max degree of a node in the GNAT. default: 12
+    min_degree: 12  # min degree of a node in the GNAT. default: 12
+    max_pts_per_leaf: 6  # max points per leaf in the GNAT. default: 6
+    estimated_dimension: 0.0  # estimated dimension of the free space. default: 0.0
+    min_valid_path_fraction: 0.2  # Accept partially valid moves above fraction. default: 0.2
+  BiTRRTkConfigDefault:
+    type: geometric::BiTRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
+    init_temperature: 100  # initial temperature. default: 100
+    frountier_threshold: 0.0  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
+    frountier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
+    cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
+  LBTRRTkConfigDefault:
+    type: geometric::LBTRRT
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+    epsilon: 0.4  # optimality approximation factor. default: 0.4
+  BiESTkConfigDefault:
+    type: geometric::BiEST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  ProjESTkConfigDefault:
+    type: geometric::ProjEST
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    goal_bias: 0.05  # When close to goal select goal, with this probability. default: 0.05
+  LazyPRMkConfigDefault:
+    type: geometric::LazyPRM
+    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+  LazyPRMstarkConfigDefault:
+    type: geometric::LazyPRMstar
+  SPARSkConfigDefault:
+    type: geometric::SPARS
+    stretch_factor: 3.0  # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
+    max_failures: 1000  # maximum consecutive failure limit. default: 1000
+  SPARStwokConfigDefault:
+    type: geometric::SPARStwo
+    stretch_factor: 3.0  # roadmap spanner stretch factor. multiplicative upper bound on path quality. It does not make sense to make this parameter more than 3. default: 3.0
+    sparse_delta_fraction: 0.25  # delta fraction for connection distance. This value represents the visibility range of sparse samples. default: 0.25
+    dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
+    max_failures: 5000  # maximum consecutive failure limit. default: 5000
+  TrajOptDefault:
+    type: geometric::TrajOpt
+
+panda_arm:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+    - FMTkConfigDefault
+    - BFMTkConfigDefault
+    - PDSTkConfigDefault
+    - STRIDEkConfigDefault
+    - BiTRRTkConfigDefault
+    - LBTRRTkConfigDefault
+    - BiESTkConfigDefault
+    - ProjESTkConfigDefault
+    - LazyPRMkConfigDefault
+    - LazyPRMstarkConfigDefault
+    - SPARSkConfigDefault
+    - SPARStwokConfigDefault
+    - TrajOptDefault
+panda_arm_hand:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+    - FMTkConfigDefault
+    - BFMTkConfigDefault
+    - PDSTkConfigDefault
+    - STRIDEkConfigDefault
+    - BiTRRTkConfigDefault
+    - LBTRRTkConfigDefault
+    - BiESTkConfigDefault
+    - ProjESTkConfigDefault
+    - LazyPRMkConfigDefault
+    - LazyPRMstarkConfigDefault
+    - SPARSkConfigDefault
+    - SPARStwokConfigDefault
+    - TrajOptDefault
+hand:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+    - FMTkConfigDefault
+    - BFMTkConfigDefault
+    - PDSTkConfigDefault
+    - STRIDEkConfigDefault
+    - BiTRRTkConfigDefault
+    - LBTRRTkConfigDefault
+    - BiESTkConfigDefault
+    - ProjESTkConfigDefault
+    - LazyPRMkConfigDefault
+    - LazyPRMstarkConfigDefault
+    - SPARSkConfigDefault
+    - SPARStwokConfigDefault
+    - TrajOptDefault

--- a/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="panda_arm_ros2_control" params="name initial_positions_file prefix">
+        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+
+        <ros2_control name="${prefix}${name}" type="system">
+            <hardware>
+                <plugin>mock_components/GenericSystem</plugin>
+            </hardware>
+            <joint name="${prefix}panda_joint1">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint1']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint2">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint2']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint3">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint3']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint4">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint4']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint5">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint5']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint6">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint6']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_joint7">
+                <command_interface name="position"/>
+                <state_interface name="position">
+                  <param name="initial_value">${initial_positions['panda_joint7']}</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+        </ros2_control>
+    </xacro:macro>
+</robot>

--- a/dual_arm_panda_moveit_config/config/panda.srdf
+++ b/dual_arm_panda_moveit_config/config/panda.srdf
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="panda">
+  <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+  <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+  <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+  <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+  <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+  <group name="left_panda_arm">
+    <chain base_link="left_panda_link0" tip_link="left_panda_link8"/>
+  </group>
+  <group name="right_panda_arm">
+    <chain base_link="right_panda_link0" tip_link="right_panda_link8"/>
+  </group>
+  <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
+  <group_state group="left_panda_arm" name="ready">
+    <joint name="left_panda_joint1" value="0"/>
+    <joint name="left_panda_joint2" value="-0.785"/>
+    <joint name="left_panda_joint3" value="0"/>
+    <joint name="left_panda_joint4" value="-2.356"/>
+    <joint name="left_panda_joint5" value="0"/>
+    <joint name="left_panda_joint6" value="1.571"/>
+    <joint name="left_panda_joint7" value="0.785"/>
+  </group_state>
+
+  <group_state group="right_panda_arm" name="ready">
+    <joint name="right_panda_joint1" value="0"/>
+    <joint name="right_panda_joint2" value="-0.785"/>
+    <joint name="right_panda_joint3" value="0"/>
+    <joint name="right_panda_joint4" value="-2.356"/>
+    <joint name="right_panda_joint5" value="0"/>
+    <joint name="right_panda_joint6" value="1.571"/>
+    <joint name="right_panda_joint7" value="0.785"/>
+  </group_state>
+
+  <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+  <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
+  <end_effector group="left_hand" name="left_hand" parent_group="left_panda_arm" parent_link="left_panda_link8"/>
+  <end_effector group="right_hand" name="right_hand" parent_group="right_panda_arm" parent_link="right_panda_link8"/>
+
+  <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+  <!-- We don't use a virtual joint here since world->left_panda_link0 and world->right_panda_link0 are already defined in the URDF -->
+
+  <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+  <disable_collisions link1="left_panda_link0" link2="left_panda_link1" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link0" link2="left_panda_link2" reason="Never"/>
+  <disable_collisions link1="left_panda_link0" link2="left_panda_link3" reason="Never"/>
+  <disable_collisions link1="left_panda_link0" link2="left_panda_link4" reason="Never"/>
+  <disable_collisions link1="left_panda_link1" link2="left_panda_link2" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link1" link2="left_panda_link3" reason="Never"/>
+  <disable_collisions link1="left_panda_link1" link2="left_panda_link4" reason="Never"/>
+  <disable_collisions link1="left_panda_link2" link2="left_panda_link3" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link2" link2="left_panda_link4" reason="Never"/>
+  <disable_collisions link1="left_panda_link2" link2="left_panda_link6" reason="Never"/>
+  <disable_collisions link1="left_panda_link3" link2="left_panda_link4" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link3" link2="left_panda_link5" reason="Never"/>
+  <disable_collisions link1="left_panda_link3" link2="left_panda_link6" reason="Never"/>
+  <disable_collisions link1="left_panda_link3" link2="left_panda_link7" reason="Never"/>
+  <disable_collisions link1="left_panda_link4" link2="left_panda_link5" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link4" link2="left_panda_link6" reason="Never"/>
+  <disable_collisions link1="left_panda_link4" link2="left_panda_link7" reason="Never"/>
+  <disable_collisions link1="left_panda_link5" link2="left_panda_link6" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_link6" link2="left_panda_link7" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_leftfinger" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_rightfinger" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_leftfinger" link2="left_panda_rightfinger" reason="Default"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_link3" reason="Never"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_link4" reason="Never"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_link6" reason="Never"/>
+  <disable_collisions link1="left_panda_hand" link2="left_panda_link7" reason="Adjacent"/>
+  <disable_collisions link1="left_panda_leftfinger" link2="left_panda_link3" reason="Never"/>
+  <disable_collisions link1="left_panda_leftfinger" link2="left_panda_link4" reason="Never"/>
+  <disable_collisions link1="left_panda_leftfinger" link2="left_panda_link6" reason="Never"/>
+  <disable_collisions link1="left_panda_leftfinger" link2="left_panda_link7" reason="Never"/>
+  <disable_collisions link1="left_panda_link3" link2="left_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="left_panda_link4" link2="left_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="left_panda_link6" link2="left_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="left_panda_link7" link2="left_panda_rightfinger" reason="Never"/>
+  <!-- Right arm -->
+  <disable_collisions link1="right_panda_link0" link2="right_panda_link1" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link0" link2="right_panda_link2" reason="Never"/>
+  <disable_collisions link1="right_panda_link0" link2="right_panda_link3" reason="Never"/>
+  <disable_collisions link1="right_panda_link0" link2="right_panda_link4" reason="Never"/>
+  <disable_collisions link1="right_panda_link1" link2="right_panda_link2" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link1" link2="right_panda_link3" reason="Never"/>
+  <disable_collisions link1="right_panda_link1" link2="right_panda_link4" reason="Never"/>
+  <disable_collisions link1="right_panda_link2" link2="right_panda_link3" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link2" link2="right_panda_link4" reason="Never"/>
+  <disable_collisions link1="right_panda_link2" link2="right_panda_link6" reason="Never"/>
+  <disable_collisions link1="right_panda_link3" link2="right_panda_link4" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link3" link2="right_panda_link5" reason="Never"/>
+  <disable_collisions link1="right_panda_link3" link2="right_panda_link6" reason="Never"/>
+  <disable_collisions link1="right_panda_link3" link2="right_panda_link7" reason="Never"/>
+  <disable_collisions link1="right_panda_link4" link2="right_panda_link5" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link4" link2="right_panda_link6" reason="Never"/>
+  <disable_collisions link1="right_panda_link4" link2="right_panda_link7" reason="Never"/>
+  <disable_collisions link1="right_panda_link5" link2="right_panda_link6" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_link6" link2="right_panda_link7" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_leftfinger" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_rightfinger" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_leftfinger" link2="right_panda_rightfinger" reason="Default"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_link3" reason="Never"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_link4" reason="Never"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_link6" reason="Never"/>
+  <disable_collisions link1="right_panda_hand" link2="right_panda_link7" reason="Adjacent"/>
+  <disable_collisions link1="right_panda_leftfinger" link2="right_panda_link3" reason="Never"/>
+  <disable_collisions link1="right_panda_leftfinger" link2="right_panda_link4" reason="Never"/>
+  <disable_collisions link1="right_panda_leftfinger" link2="right_panda_link6" reason="Never"/>
+  <disable_collisions link1="right_panda_leftfinger" link2="right_panda_link7" reason="Never"/>
+  <disable_collisions link1="right_panda_link3" link2="right_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="right_panda_link4" link2="right_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="right_panda_link6" link2="right_panda_rightfinger" reason="Never"/>
+  <disable_collisions link1="right_panda_link7" link2="right_panda_rightfinger" reason="Never"/>
+
+</robot>

--- a/dual_arm_panda_moveit_config/config/panda.urdf.xacro
+++ b/dual_arm_panda_moveit_config/config/panda.urdf.xacro
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
+
+    <xacro:arg name="left_initial_positions_file"
+            default="$(find dual_arm_panda_moveit_config)/config/left_initial_positions.yaml"/>
+    <xacro:arg name="right_initial_positions_file"
+            default="$(find dual_arm_panda_moveit_config)/config/right_initial_positions.yaml"/>
+
+    <!-- Root link -->
+    <link name="world"/>
+
+    <!-- Xacro imports -->
+    <xacro:include filename="panda_arm_macro.xacro" />
+
+    <!-- Left arm -->
+    <xacro:panda_arm
+        name="left_panda"
+        prefix="left_"
+        parent="world"
+        initial_positions_file="$(arg left_initial_positions_file)">
+        <origin xyz="0 -1.5 0" rpy="0 0 0" />
+    </xacro:panda_arm>
+
+    <!-- Right arm -->
+    <xacro:panda_arm
+        name="right_panda"
+        prefix="right_"
+        parent="world"
+        initial_positions_file="$(arg right_initial_positions_file)">
+        <origin xyz="0 1.5 0" rpy="0 0 0" />
+    </xacro:panda_arm>
+</robot>

--- a/dual_arm_panda_moveit_config/config/panda_arm_macro.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_arm_macro.xacro
@@ -1,0 +1,238 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="panda_arm" params="name prefix parent *origin initial_positions_file" >
+
+        <!-- ros2_control -->
+        <xacro:include filename="$(find dual_arm_panda_moveit_config)/config/panda.ros2_control.xacro" />
+        <xacro:panda_arm_ros2_control name="${name}" initial_positions_file="${initial_positions_file}" prefix="${prefix}"/>
+
+        <xacro:include filename="panda_hand.ros2_control.xacro" />
+        <xacro:panda_hand_ros2_control name="${name}" prefix="${prefix}"/>
+
+        <!-- base_joint fixes base_link to the environment -->
+        <joint name="${prefix}base_joint" type="fixed">
+            <xacro:insert_block name="origin" />
+            <parent link="${parent}" />
+            <child link="${prefix}panda_link0" />
+        </joint>
+
+        <link name="${prefix}panda_link0">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link0.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link0.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}panda_link1">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link1.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link1.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint1" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" />
+            <origin rpy="0 0 0" xyz="0 0 0.333" />
+            <parent link="${prefix}panda_link0" />
+            <child link="${prefix}panda_link1" />
+            <axis xyz="0 0 1" />
+            <limit effort="87" lower="-2.9671" upper="2.9671" velocity="2.3925" />
+        </joint>
+        <link name="${prefix}panda_link2">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link2.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link2.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint2" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-1.7628" soft_upper_limit="1.7628" />
+            <origin rpy="-1.57079632679 0 0" xyz="0 0 0" />
+            <parent link="${prefix}panda_link1" />
+            <child link="${prefix}panda_link2" />
+            <axis xyz="0 0 1" />
+            <limit effort="87" lower="-1.8326" upper="1.8326" velocity="2.3925" />
+        </joint>
+        <link name="${prefix}panda_link3">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link3.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link3.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint3" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" />
+            <origin rpy="1.57079632679 0 0" xyz="0 -0.316 0" />
+            <parent link="${prefix}panda_link2" />
+            <child link="${prefix}panda_link3" />
+            <axis xyz="0 0 1" />
+            <limit effort="87" lower="-2.9671" upper="2.9671" velocity="2.3925" />
+        </joint>
+        <link name="${prefix}panda_link4">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link4.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link4.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint4" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-3.0718" soft_upper_limit="0.0175" />
+            <origin rpy="1.57079632679 0 0" xyz="0.0825 0 0" />
+            <parent link="${prefix}panda_link3" />
+            <child link="${prefix}panda_link4" />
+            <axis xyz="0 0 1" />
+            <limit effort="87" lower="-3.1416" upper="0.0873" velocity="2.3925" />
+        </joint>
+        <link name="${prefix}panda_link5">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link5.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link5.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint5" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" />
+            <origin rpy="-1.57079632679 0 0" xyz="-0.0825 0.384 0" />
+            <parent link="${prefix}panda_link4" />
+            <child link="${prefix}panda_link5" />
+            <axis xyz="0 0 1" />
+            <limit effort="12" lower="-2.9671" upper="2.9671" velocity="2.8710" />
+        </joint>
+        <link name="${prefix}panda_link6">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link6.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link6.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint6" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-0.0175" soft_upper_limit="3.7525" />
+            <origin rpy="1.57079632679 0 0" xyz="0 0 0" />
+            <parent link="${prefix}panda_link5" />
+            <child link="${prefix}panda_link6" />
+            <axis xyz="0 0 1" />
+            <limit effort="12" lower="-0.0873" upper="3.8223" velocity="2.8710" />
+        </joint>
+        <link name="${prefix}panda_link7">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/link7.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/link7.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_joint7" type="revolute">
+            <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973" />
+            <origin rpy="1.57079632679 0 0" xyz="0.088 0 0" />
+            <parent link="${prefix}panda_link6" />
+            <child link="${prefix}panda_link7" />
+            <axis xyz="0 0 1" />
+            <limit effort="12" lower="-2.9671" upper="2.9671" velocity="2.8710" />
+        </joint>
+        <link name="${prefix}panda_link8" />
+        <joint name="${prefix}panda_joint8" type="fixed">
+            <origin rpy="0 0 0" xyz="0 0 0.107" />
+            <parent link="${prefix}panda_link7" />
+            <child link="${prefix}panda_link8" />
+            <axis xyz="0 0 0" />
+        </joint>
+        <joint name="${prefix}panda_hand_joint" type="fixed">
+            <parent link="${prefix}panda_link8" />
+            <child link="${prefix}panda_hand" />
+            <origin rpy="0 0 -0.785398163397" xyz="0 0 0" />
+        </joint>
+        <link name="${prefix}panda_hand">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/hand.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/hand.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}panda_leftfinger">
+            <visual>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/finger.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/finger.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <link name="${prefix}panda_rightfinger">
+            <visual>
+                <origin rpy="0 0 3.14159265359" xyz="0 0 0" />
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/visual/finger.dae" />
+                </geometry>
+            </visual>
+            <collision>
+                <origin rpy="0 0 3.14159265359" xyz="0 0 0" />
+                <geometry>
+                    <mesh filename="package://moveit_resources_panda_description/meshes/collision/finger.stl" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${prefix}panda_finger_joint1" type="prismatic">
+            <parent link="${prefix}panda_hand" />
+            <child link="${prefix}panda_leftfinger" />
+            <origin rpy="0 0 0" xyz="0 0 0.0584" />
+            <axis xyz="0 1 0" />
+            <limit effort="20" lower="0.0" upper="0.04" velocity="0.2" />
+        </joint>
+        <joint name="${prefix}panda_finger_joint2" type="prismatic">
+            <parent link="${prefix}panda_hand" />
+            <child link="${prefix}panda_rightfinger" />
+            <origin rpy="0 0 0" xyz="0 0 0.0584" />
+            <axis xyz="0 -1 0" />
+            <limit effort="20" lower="0.0" upper="0.04" velocity="0.2" />
+            <mimic joint="${prefix}panda_finger_joint1" />
+        </joint>
+    </xacro:macro>
+</robot>

--- a/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="panda_hand_ros2_control" params="name prefix">
+        <ros2_control name="${name}" type="system">
+            <hardware>
+                <plugin>mock_components/GenericSystem</plugin>
+            </hardware>
+            <joint name="${prefix}panda_finger_joint1">
+                <command_interface name="position" />
+                <state_interface name="position">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="${prefix}panda_finger_joint2">
+                <param name="mimic">${prefix}panda_finger_joint1</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
+                <state_interface name="position">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity"/>
+            </joint>
+        </ros2_control>
+    </xacro:macro>
+
+</robot>

--- a/dual_arm_panda_moveit_config/config/pilz_cartesian_limits.yaml
+++ b/dual_arm_panda_moveit_config/config/pilz_cartesian_limits.yaml
@@ -1,0 +1,5 @@
+cartesian_limits:
+  max_trans_vel: 1.0
+  max_trans_acc: 2.25
+  max_trans_dec: -5.0
+  max_rot_vel: 1.57

--- a/dual_arm_panda_moveit_config/config/right_initial_positions.yaml
+++ b/dual_arm_panda_moveit_config/config/right_initial_positions.yaml
@@ -1,0 +1,9 @@
+# Default initial positions for the panda arm's ros2_control fake system
+initial_positions:
+  panda_joint1: 0.0
+  panda_joint2: -0.785
+  panda_joint3: 0.0
+  panda_joint4: -2.356
+  panda_joint5: 0.0
+  panda_joint6: 1.571
+  panda_joint7: 0.785

--- a/dual_arm_panda_moveit_config/config/ros2_controllers.yaml
+++ b/dual_arm_panda_moveit_config/config/ros2_controllers.yaml
@@ -1,0 +1,46 @@
+# This config file is used by ros2_control
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    left_arm_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    right_arm_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+
+left_arm_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - left_panda_joint1
+      - left_panda_joint2
+      - left_panda_joint3
+      - left_panda_joint4
+      - left_panda_joint5
+      - left_panda_joint6
+      - left_panda_joint7
+
+right_arm_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - right_panda_joint1
+      - right_panda_joint2
+      - right_panda_joint3
+      - right_panda_joint4
+      - right_panda_joint5
+      - right_panda_joint6
+      - right_panda_joint7

--- a/dual_arm_panda_moveit_config/launch/demo.launch.py
+++ b/dual_arm_panda_moveit_config/launch/demo.launch.py
@@ -1,0 +1,91 @@
+import os
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.actions import ExecuteProcess
+from ament_index_python.packages import get_package_share_directory
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+def generate_launch_description():
+
+    moveit_config = (
+        MoveItConfigsBuilder("dual_arm_panda")
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .robot_description_semantic(file_path="config/panda.srdf")
+        .trajectory_execution(file_path="config/moveit_controllers.yaml")
+        .planning_pipelines(pipelines=["ompl"])
+        .to_moveit_configs()
+    )
+
+    # Start the actual move_group node/action server
+    move_group_node = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=[moveit_config.to_dict()],
+    )
+
+    # RViz
+    rviz_config = os.path.join(
+        get_package_share_directory("dual_arm_panda_moveit_config"),
+        "launch/moveit.rviz",
+    )
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="log",
+        arguments=["-d", rviz_config],
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.planning_pipelines,
+            moveit_config.robot_description_kinematics,
+        ],
+    )
+    # Publish TF
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[moveit_config.robot_description],
+    )
+
+    # ros2_control using FakeSystem as hardware
+    ros2_controllers_path = os.path.join(
+        get_package_share_directory("dual_arm_panda_moveit_config"),
+        "config/",
+        "ros2_controllers.yaml",
+    )
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        output="both",
+    )
+
+    # Load controllers
+    load_controllers = []
+    for controller in [
+        "joint_state_broadcaster",
+        "left_arm_controller",
+        "right_arm_controller",
+    ]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
+
+    return LaunchDescription(
+        [
+            rviz_node,
+            robot_state_publisher,
+            move_group_node,
+            ros2_control_node,
+        ]
+        + load_controllers
+    )

--- a/dual_arm_panda_moveit_config/launch/moveit.rviz
+++ b/dual_arm_panda_moveit_config/launch/moveit.rviz
@@ -1,0 +1,760 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded: ~
+      Splitter Ratio: 0.5
+    Tree Height: 416
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Topic:
+        Depth: 100
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rviz_visual_tools
+      Value: true
+    - Class: moveit_rviz_plugin/Trajectory
+      Color Enabled: false
+      Enabled: true
+      Interrupt Display: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        left_panda_hand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_panda_link8:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        left_panda_rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_hand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_panda_link8:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        right_panda_rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Loop Animation: false
+      Name: Trajectory
+      Robot Alpha: 0.5
+      Robot Color: 150; 50; 150
+      Robot Description: robot_description
+      Show Robot Collision: false
+      Show Robot Visual: true
+      Show Trail: false
+      State Display Time: 0.05 s
+      Trail Step Size: 1
+      Trajectory Topic: /display_planned_path
+      Use Sim Time: false
+      Value: true
+    - Class: moveit_rviz_plugin/PlanningScene
+      Enabled: false
+      Move Group Namespace: ""
+      Name: PlanningScene
+      Planning Scene Topic: /monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.009999999776482582
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          left_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          left_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          right_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: false
+    - Acceleration_Scaling_Factor: 0.1
+      Class: moveit_rviz_plugin/MotionPlanning
+      Enabled: true
+      Move Group Namespace: ""
+      MoveIt_Allow_Approximate_IK: false
+      MoveIt_Allow_External_Program: false
+      MoveIt_Allow_Replanning: false
+      MoveIt_Allow_Sensor_Positioning: false
+      MoveIt_Planning_Attempts: 10
+      MoveIt_Planning_Time: 5
+      MoveIt_Use_Cartesian_Path: false
+      MoveIt_Use_Constraint_Aware_IK: false
+      MoveIt_Workspace:
+        Center:
+          X: 0
+          Y: 0
+          Z: 0
+        Size:
+          X: 2
+          Y: 2
+          Z: 2
+      Name: MotionPlanning
+      Planned Path:
+        Color Enabled: false
+        Interrupt Display: false
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          left_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          left_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          right_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+        Loop Animation: false
+        Robot Alpha: 0.5
+        Robot Color: 150; 50; 150
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 3x
+        Trail Step Size: 1
+        Trajectory Topic: /display_planned_path
+        Use Sim Time: false
+      Planning Metrics:
+        Payload: 1
+        Show Joint Torques: false
+        Show Manipulability: false
+        Show Manipulability Index: false
+        Show Weight Limit: false
+        TextHeight: 0.07999999821186066
+      Planning Request:
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0.20000000298023224
+        Joint Violation Color: 255; 0; 255
+        Planning Group: left_panda_arm
+        Query Goal State: true
+        Query Start State: false
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planning Scene Topic: /monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.009999999776482582
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          left_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          left_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          left_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          right_panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          right_panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          world:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+      Velocity_Scaling_Factor: 0.1
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 4.6314778327941895
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.23990310728549957
+        Y: -0.014547418802976608
+        Z: 0.32880711555480957
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.1303984373807907
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.508573532104492
+    Saved: ~
+Window Geometry:
+  "":
+    collapsed: false
+  " - Trajectory Slider":
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1043
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001f3000003b9fc020000000bfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000022b000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000003c005400720061006a006500630074006f007200790020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004100fffffffb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004100fffffffbffffffff010000026e000001880000017d00ffffff000000010000010f000003abfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b000003ab000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000587000003b900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Trajectory - Trajectory Slider:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 0
+  Y: 0

--- a/dual_arm_panda_moveit_config/package.xml
+++ b/dual_arm_panda_moveit_config/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>dual_arm_panda_moveit_config</name>
+  <version>0.1.0</version>
+  <description>
+    <p>
+      Dual Franka Emika Panda MoveIt Configuration 
+    </p>
+  </description>
+  <author email="mike@picknik.ai">Mike Lautman</author>
+  <maintainer email="mike@picknik.ai">Mike Lautman</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://moveit.ros.org/</url>
+  <url type="bugtracker">https://github.com/ros-planning/moveit_resources/issues</url>
+  <url type="repository">https://github.com/ros-planning/moveit_resources</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>moveit_resources_panda_description</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_kinematics</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+      <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
The [`moveit2_tutorials`](https://github.com/ros-planning/moveit2_tutorials) repo is failing to build right now because it was using a `dual_arm_panda_moveit_config` package that is fully contained inside the `moveit2_tutorials` package, which actually is [not supported](https://github.com/ros-planning/moveit2_tutorials).

This PR aims to bring in the config into this repo so it can be brought in as a separate colcon package.

For now, I will have a fix to unbreak CI in `moveit2_tutorials`, but this is long-term the "right" solution.