### PR TITLE
Enable acceleration limits for panda hand

### DIFF
--- a/panda_moveit_config/config/joint_limits.yaml
+++ b/panda_moveit_config/config/joint_limits.yaml
@@ -46,10 +46,10 @@ joint_limits:
   panda_finger_joint1:
     has_velocity_limits: true
     max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0.0
+    has_acceleration_limits: true
+    max_acceleration: 1.0
   panda_finger_joint2:
     has_velocity_limits: true
     max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0.0
+    has_acceleration_limits: true
+    max_acceleration: 1.0


### PR DESCRIPTION
The MTC pick and place demo in the moveit2_tutorials is broken with the following error message:
```cpp
[pick_place_demo-1] [WARN] [1680007103.217881120] [moveit_ros.add_time_optimal_parameterization]:  Time parametrization for the solution path failed.
[pick_place_demo-1] [INFO] [1680007103.219394083] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'hand' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[pick_place_demo-1] [ERROR] [1680007103.246561612] [moveit_trajectory_processing.time_optimal_trajectory_generation]: No acceleration limit was defined for joint panda_finger_joint1! You have to define acceleration limits in the URDF or joint_limits.yaml
[pick_place_demo-1] [WARN] [1680007103.246569417] [moveit_ros.add_time_optimal_parameterization]:  Time parametrization for the solution path failed.
[pick_place_demo-1] [INFO] [1680007103.248153685] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'hand' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[pick_place_demo-1] [ERROR] [1680007103.275264136] [moveit_trajectory_processing.time_optimal_trajectory_generation]: No acceleration limit was defined for joint panda_finger_joint1! You have to define acceleration limits in the URDF or joint_limits.yaml
[pick_place_demo-1] [WARN] [1680007103.275270829] [moveit_ros.add_time_optimal_parameterization]:  Time parametrization for the solution path failed.
[pick_place_demo-1] [INFO] [1680007103.278590133] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'hand' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[pick_place_demo-1] [ERROR] [1680007103.304140281] [moveit_trajectory_processing.time_optimal_trajectory_generation]: No acceleration limit was defined for joint panda_finger_joint1! You have to define acceleration limits in the URDF or joint_limits.yaml
[pick_place_demo-1] [WARN] [1680007103.304148176] [moveit_ros.add_time_optimal_parameterization]:  Time parametrization for the solution path failed.
[pick_place_demo-1] [INFO] [1680007103.315600044] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'hand' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[pick_place_demo-1] [ERROR] [1680007103.343903137] [moveit_trajectory_processing.time_optimal_trajectory_generation]: No acceleration limit was defined for joint panda_finger_joint1! You have to define acceleration limits in the URDF or joint_limits.yaml
[pick_place_demo-1] [WARN] [1680007103.343909669] [moveit_ros.add_time_optimal_parameterization]:  Time parametrization for the solution path failed.
[pick_place_demo-1] [INFO] [1680007103.345764513] [moveit.ompl_planning.model_based_planning_context]: Planner configuration 'hand' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[pick_place_demo-1] [ERROR] [1680007103.374110297] [moveit_trajectory_processing.time_optimal_trajectory_generation]: No acceleration limit was defined for joint panda_finger_joint1! You have to define acceleration limits in the URDF or joint_limits.yaml
```
This happens because of https://github.com/ros-planning/moveit2/commit/937be8eba7bf0df3a3a59d99a71f68029239ef4e where the existence of acceleration limits is made mandatory if you want to apply TOTG to a trajectory (otherwise the algorithm does not work properly). This PR enables the limits for the panda hand with the default values that were previously used if no acceleration limits existed. 