### PR TITLE
Enable anytime and fix benchmarks

### DIFF
--- a/benchmarking/launch/run_benchmark.launch.py
+++ b/benchmarking/launch/run_benchmark.launch.py
@@ -21,10 +21,10 @@ def load_yaml(package_name, file_path):
 def generate_launch_description():
 
     moveit_ros_benchmarks_config = (
-        ParameterBuilder("moveit_ros_benchmarks")
+        ParameterBuilder("moveit_resources_benchmarking")
         .yaml(
             parameter_namespace="benchmark_config",
-            file_path="run_benchmark.yaml",
+            file_path="config/run_benchmark.yaml",
         )
         .to_dict()
     )
@@ -34,8 +34,8 @@ def generate_launch_description():
         .robot_description(file_path="config/panda.urdf.xacro")
         .planning_pipelines("ompl", ["ompl", "chomp", "pilz_industrial_motion_planner"])
         .moveit_cpp(
-            file_path=get_package_share_directory("moveit_ros_benchmarks")
-            + "/moveit_cpp.yaml"
+            file_path=get_package_share_directory("moveit_resources_benchmarking")
+            + "/config/moveit_cpp.yaml"
         )
         .to_moveit_configs()
     )
@@ -61,7 +61,7 @@ def generate_launch_description():
 
     sqlite_database = (
         get_package_share_directory("moveit_resources_benchmarking")
-        + "/panda_test_db.sqlite"
+        + "/databases/panda_test_db.sqlite"
     )
 
     warehouse_ros_config = {

--- a/fanuc_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_moveit_config/config/ompl_planning.yaml
@@ -10,11 +10,11 @@ start_state_max_bounds_error: 0.1
 planner_configs:
   AnytimePathShortening:
     type: geometric::AnytimePathShortening
-    shortcut: true  # Attempt to shortcut all new solution paths
-    hybridize: true  # Compute hybrid solution trajectories
+    shortcut: 1  # Attempt to shortcut all new solution paths
+    hybridize: 1  # Compute hybrid solution trajectories
     max_hybrid_paths: 24  # Number of hybrid paths generated per iteration
     num_planners: 4  # The number of default planners to use for planning
-    planners: ""  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
+    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
   SBL:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/fanuc_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_moveit_config/config/ompl_planning.yaml
@@ -12,9 +12,9 @@ planner_configs:
     type: geometric::AnytimePathShortening
     shortcut: 1  # Attempt to shortcut all new solution paths
     hybridize: 1  # Compute hybrid solution trajectories
-    max_hybrid_paths: 24  # Number of hybrid paths generated per iteration
-    num_planners: 4  # The number of default planners to use for planning
-    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
+    max_hybrid_paths: 36  # Number of hybrid paths generated per iteration
+    num_planners: 8  # The number of default planners to use for planning
+    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
   SBL:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -12,9 +12,9 @@ planner_configs:
     type: geometric::AnytimePathShortening
     shortcut: 1  # Attempt to shortcut all new solution paths
     hybridize: 1  # Compute hybrid solution trajectories
-    max_hybrid_paths: 24  # Number of hybrid paths generated per iteration
-    num_planners: 4  # The number of default planners to use for planning
-    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
+    max_hybrid_paths: 36  # Number of hybrid paths generated per iteration
+    num_planners: 8  # The number of default planners to use for planning
+    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
   SBLkConfigDefault:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -8,7 +8,7 @@ request_adapters: >-
   default_planner_request_adapters/FixStartStatePathConstraints
 start_state_max_bounds_error: 0.1
 planner_configs:
-  AnytimePathShortening:
+  APSConfigDefault:
     type: geometric::AnytimePathShortening
     shortcut: 1  # Attempt to shortcut all new solution paths
     hybridize: 1  # Compute hybrid solution trajectories
@@ -141,7 +141,7 @@ planner_configs:
 
 panda_arm:
   planner_configs:
-    - AnytimePathShortening
+    - APSConfigDefault
     - SBLkConfigDefault
     - ESTkConfigDefault
     - LBKPIECEkConfigDefault
@@ -168,6 +168,7 @@ panda_arm:
     - TrajOptDefault
 panda_arm_hand:
   planner_configs:
+    - APSConfigDefault
     - SBLkConfigDefault
     - ESTkConfigDefault
     - LBKPIECEkConfigDefault
@@ -194,6 +195,7 @@ panda_arm_hand:
     - TrajOptDefault
 hand:
   planner_configs:
+    - APSConfigDefault
     - SBLkConfigDefault
     - ESTkConfigDefault
     - LBKPIECEkConfigDefault

--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -8,6 +8,13 @@ request_adapters: >-
   default_planner_request_adapters/FixStartStatePathConstraints
 start_state_max_bounds_error: 0.1
 planner_configs:
+  AnytimePathShortening:
+    type: geometric::AnytimePathShortening
+    shortcut: 1  # Attempt to shortcut all new solution paths
+    hybridize: 1  # Compute hybrid solution trajectories
+    max_hybrid_paths: 24  # Number of hybrid paths generated per iteration
+    num_planners: 4  # The number of default planners to use for planning
+    planners: "RRTConnect,RRTConnect,RRTConnect,RRTConnect"  # A comma-separated list of planner types (e.g., "PRM,EST,RRTConnect"Optionally, planner parameters can be passed to change the default:"PRM[max_nearest_neighbors=5],EST[goal_bias=.5],RRT[range=10. goal_bias=.1]"
   SBLkConfigDefault:
     type: geometric::SBL
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
@@ -134,6 +141,7 @@ planner_configs:
 
 panda_arm:
   planner_configs:
+    - AnytimePathShortening
     - SBLkConfigDefault
     - ESTkConfigDefault
     - LBKPIECEkConfigDefault


### PR DESCRIPTION
This PR does two things:
- Update some wrong filenames of the benchmarking launch file
- Add the config necessary use AnytimePathShortening