### PR TITLE
Remove comments from scalars

### DIFF
--- a/dual_arm_panda_moveit_config/config/ompl_planning.yaml
+++ b/dual_arm_panda_moveit_config/config/ompl_planning.yaml
@@ -1,7 +1,7 @@
 planning_plugin: ompl_interface/OMPLPlanner
+# To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
+# default_planner_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters: >-
-  # Optionally use Ruckig for jerk-limited smoothing
-  # default_planner_request_adapters/AddRuckigTrajectorySmoothing
   default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds

--- a/fanuc_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_moveit_config/config/ompl_planning.yaml
@@ -1,7 +1,7 @@
 planning_plugin: ompl_interface/OMPLPlanner
+# To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
+# default_planner_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters: >-
-  # Optionally use Ruckig for jerk-limited smoothing
-  # default_planner_request_adapters/AddRuckigTrajectorySmoothing
   default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds

--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -1,7 +1,7 @@
 planning_plugin: ompl_interface/OMPLPlanner
+# To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
+# default_planner_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters: >-
-  # Optionally use Ruckig for jerk-limited smoothing
-  # default_planner_request_adapters/AddRuckigTrajectorySmoothing
   default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds


### PR DESCRIPTION
The [YAML specification](https://yaml.org/spec/1.2-old/spec.html#id2767100) does not support comments inside scalars, such as the one used to specify `request_adapters`. These lines will not be interpreted correctly. This PR moves the comments outside of the scalar such that they are properly interpreted as comments.

I wrote [this script](https://gist.github.com/stephanie-eng/6fd434a631a9a2d8d5c39ff33642b8df) to check the repo for all potential issues of this nature and fixed the three that it found.