### PR TITLE
fix warnings about deprecated load_yaml

### DIFF
--- a/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="panda_arm_ros2_control" params="name initial_positions_file prefix">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${prefix}${name}" type="system">
             <hardware>

--- a/fanuc_moveit_config/config/fanuc.ros2_control.xacro
+++ b/fanuc_moveit_config/config/fanuc.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="fanuc_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>


### PR DESCRIPTION
Fix warnings about the deprecation of `load_yaml` in macros `panda_arm_ros2_control` and `fanuc_ros2_control` in the same way they have been fixed in https://github.com/ros-planning/moveit_resources/pull/156 for macro `panda_ros2_control`.