### PR TITLE
Update planner plugin configs

### DIFF
--- a/dual_arm_panda_moveit_config/config/ompl_planning.yaml
+++ b/dual_arm_panda_moveit_config/config/ompl_planning.yaml
@@ -1,4 +1,5 @@
-planning_plugin: ompl_interface/OMPLPlanner
+planning_plugins:
+  - ompl_interface/OMPLPlanner
 # To optionally use Ruckig for jerk-limited smoothing, add this line to the response adapters below
 # - default_planning_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters:

--- a/fanuc_moveit_config/config/chomp_planning.yaml
+++ b/fanuc_moveit_config/config/chomp_planning.yaml
@@ -1,4 +1,6 @@
-planning_plugin: chomp_interface/CHOMPPlanner
+planning_plugins:
+  - chomp_interface/CHOMPPlanner
+# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
   - default_planning_request_adapters/ValidateWorkspaceBounds

--- a/fanuc_moveit_config/config/ompl_planning.yaml
+++ b/fanuc_moveit_config/config/ompl_planning.yaml
@@ -1,4 +1,5 @@
-planning_plugin: ompl_interface/OMPLPlanner
+planning_plugins:
+  - ompl_interface/OMPLPlanner
 # To optionally use Ruckig for jerk-limited smoothing, add this line to the response adapters below
 # - default_planning_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters:

--- a/panda_moveit_config/config/chomp_planning.yaml
+++ b/panda_moveit_config/config/chomp_planning.yaml
@@ -1,4 +1,6 @@
-planning_plugin: chomp_interface/CHOMPPlanner
+planning_plugins:
+  - chomp_interface/CHOMPPlanner
+# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
   - default_planning_request_adapters/ValidateWorkspaceBounds

--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -1,4 +1,5 @@
-planning_plugin: ompl_interface/OMPLPlanner
+planning_plugins:
+  - ompl_interface/OMPLPlanner
 # To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
 # default_planning_request_adapters/AddRuckigTrajectorySmoothing
 request_adapters:

--- a/panda_moveit_config/config/pilz_industrial_motion_planner_planning.yaml
+++ b/panda_moveit_config/config/pilz_industrial_motion_planner_planning.yaml
@@ -1,4 +1,6 @@
-planning_plugin: pilz_industrial_motion_planner/CommandPlanner
+planning_plugins:
+  - pilz_industrial_motion_planner/CommandPlanner
+# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
 request_adapters:
   - default_planning_request_adapters/ValidateWorkspaceBounds
   - default_planning_request_adapters/CheckStartStateBounds

--- a/panda_moveit_config/config/stomp_planning.yaml
+++ b/panda_moveit_config/config/stomp_planning.yaml
@@ -1,4 +1,6 @@
-planning_plugin: stomp_moveit/StompPlanner
+planning_plugins:
+  - stomp_moveit/StompPlanner
+# The order of the elements in the adapter corresponds to the order they are processed by the motion planning pipeline.
 request_adapters:
   - default_planning_request_adapters/ResolveConstraintFrames
   - default_planning_request_adapters/ValidateWorkspaceBounds


### PR DESCRIPTION
Blocked by https://github.com/ros-planning/moveit2/pull/2457

Makes the planner plugin parameter a vector.