### PR TITLE
Update ros2 control usage

### DIFF
--- a/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda.ros2_control.xacro
@@ -13,49 +13,63 @@
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint1']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint2">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint2']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint3">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint3']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint4">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint4']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint5">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint5']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint6">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint6']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_joint7">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint7']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -12,6 +12,8 @@
                   <param name="initial_value">0.0</param>
                 </state_interface>
                 <state_interface name="velocity"/>
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="${prefix}panda_finger_joint2">
                 <param name="mimic">${prefix}panda_finger_joint1</param>
@@ -21,6 +23,8 @@
                   <param name="initial_value">0.0</param>
                 </state_interface>
                 <state_interface name="velocity"/>
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -11,7 +11,7 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
                     <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>
@@ -22,7 +22,7 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
                     <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>

--- a/dual_arm_panda_moveit_config/launch/demo.launch.py
+++ b/dual_arm_panda_moveit_config/launch/demo.launch.py
@@ -61,7 +61,10 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="both",
     )
 

--- a/fanuc_moveit_config/config/fanuc.ros2_control.xacro
+++ b/fanuc_moveit_config/config/fanuc.ros2_control.xacro
@@ -13,42 +13,54 @@
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_1']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="joint_2">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_2']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="joint_3">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_3']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="joint_4">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_4']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="joint_5">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_5']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="joint_6">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['joint_6']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/fanuc_moveit_config/launch/demo.launch.py
+++ b/fanuc_moveit_config/launch/demo.launch.py
@@ -79,7 +79,10 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="both",
     )
 

--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -20,49 +20,63 @@
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint1']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint2">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint2']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint3">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint3']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint4">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint4']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint5">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint5']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint6">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint6']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_joint7">
                 <command_interface name="position"/>
                 <state_interface name="position">
                   <param name="initial_value">${initial_positions['panda_joint7']}</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                  <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -18,7 +18,9 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="panda_finger_joint2">
                 <param name="mimic">panda_finger_joint1</param>
@@ -27,7 +29,9 @@
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>
-                <state_interface name="velocity"/>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
     </xacro:macro>

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -105,7 +105,10 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[moveit_config.robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
         output="screen",
     )
 


### PR DESCRIPTION
Addresses these deprecation warnings
```
[Deprecated] Passing the robot description parameter directly to the control_manager node is deprecated. Use '~/robot_description' topic from 'robot_state_publisher' instead.
```
and
```
Parsing of optional initial interface values failed or uses a deprecated format. Add initial values for every state interface in the ros2_control.xacro. For example:
[ros2_control_node-5] <state_interface name="velocity">
[ros2_control_node-5]   <param name="initial_value">0.0</param>
[ros2_control_node-5] </state_interface>
```