### PR TITLE
Remove .gitattributes to avoid using LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.sqlite filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
See https://github.com/ros2-gbp/moveit_resources-release/issues/1#issuecomment-1929470104 - currently the release repo is out of the allocated quota and cannot be mirrored. @v4hn suggested removing the `.gitattributes` which should not be required anymore after the `benchmarks` packages were moved to another repo.