### PR TITLE
Allow nonzero velocity at trajectory end for ros2_controllers

### DIFF
--- a/dual_arm_panda_moveit_config/config/ros2_controllers.yaml
+++ b/dual_arm_panda_moveit_config/config/ros2_controllers.yaml
@@ -28,6 +28,7 @@ left_arm_controller:
       - left_panda_joint5
       - left_panda_joint6
       - left_panda_joint7
+    allow_nonzero_velocity_at_trajectory_end: true
 
 right_arm_controller:
   ros__parameters:
@@ -44,3 +45,4 @@ right_arm_controller:
       - right_panda_joint5
       - right_panda_joint6
       - right_panda_joint7
+    allow_nonzero_velocity_at_trajectory_end: true

--- a/fanuc_moveit_config/config/ros2_controllers.yaml
+++ b/fanuc_moveit_config/config/ros2_controllers.yaml
@@ -24,3 +24,4 @@ fanuc_controller:
       - joint_4
       - joint_5
       - joint_6
+    allow_nonzero_velocity_at_trajectory_end: true

--- a/panda_moveit_config/config/ros2_controllers.yaml
+++ b/panda_moveit_config/config/ros2_controllers.yaml
@@ -28,6 +28,7 @@ panda_arm_controller:
       - panda_joint5
       - panda_joint6
       - panda_joint7
+    allow_nonzero_velocity_at_trajectory_end: true
 
 panda_hand_controller:
   ros__parameters:


### PR DESCRIPTION
While fixing https://github.com/ros-planning/moveit2/issues/2733, I noticed that this was now needed for our servo configs if we are using the acceleration limited plugin.

This has been needed since November 2023 for this use case: https://github.com/ros-controls/ros2_controllers/pull/834, noting the parameter only exists on Rolling, and not on Humble.

cc @ibrahiminfinite