### PR TITLE
Fix name of execution_duration_monitoring parameter

### DIFF
--- a/fanuc_moveit_config/config/moveit_controllers.yaml
+++ b/fanuc_moveit_config/config/moveit_controllers.yaml
@@ -3,7 +3,7 @@ trajectory_execution:
   allowed_execution_duration_scaling: 1.2
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
-  trajectory_duration_monitoring: true
+  execution_duration_monitoring: true
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 

--- a/panda_moveit_config/config/moveit_controllers.yaml
+++ b/panda_moveit_config/config/moveit_controllers.yaml
@@ -3,7 +3,7 @@ trajectory_execution:
   allowed_execution_duration_scaling: 1.2
   allowed_goal_duration_margin: 0.5
   allowed_start_tolerance: 0.01
-  trajectory_duration_monitoring: true
+  execution_duration_monitoring: true
 
 moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 


### PR DESCRIPTION
This was added in #160 but I guess accidentally (since the title uses the correct name) with a wrong name for the `execution_duration_monitoring` parameter.