### PR TITLE
fix panda_finger_jointt2

### DIFF
--- a/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/dual_arm_panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -16,6 +16,9 @@
                 </state_interface>
             </joint>
             <joint name="${prefix}panda_finger_joint2">
+                <param name="mimic">${prefix}panda_finger_joint1</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -23,6 +23,9 @@
                 </state_interface>
             </joint>
             <joint name="panda_finger_joint2">
+                <param name="mimic">panda_finger_joint1</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
                 <state_interface name="position">
                   <param name="initial_value">0.0</param>
                 </state_interface>


### PR DESCRIPTION
The `panda_hand.ros2_control.xacro` in `path panda_moveit_config/config/ `and `dual_arm_panda_moveit_config/config/ `have some lines missing in comparison to the humble branch. This problem makes the `panda_finger_joint2` fail to move when executing the planned movement.