### PR TITLE
Remove dependency to gripper_controllers

### DIFF
--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -34,7 +34,6 @@
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>topic_tools</exec_depend>


### PR DESCRIPTION
The package has been deleted upstream and isn't used by the package, anyway.

The package builds fine in the buildfarm, but the apt package isn't installable.