### PR TITLE
Fix chomp parameter from string to double

### DIFF
--- a/fanuc_moveit_config/config/chomp_planning.yaml
+++ b/fanuc_moveit_config/config/chomp_planning.yaml
@@ -21,7 +21,7 @@ smoothness_cost_acceleration: 1.0
 smoothness_cost_jerk: 0.0
 ridge_factor: 0.01
 use_pseudo_inverse: false
-pseudo_inverse_ridge_factor: 1e-4
+pseudo_inverse_ridge_factor: 0.0001
 joint_update_limit: 0.1
 collision_clearance: 0.2
 collision_threshold: 0.07

--- a/panda_moveit_config/config/chomp_planning.yaml
+++ b/panda_moveit_config/config/chomp_planning.yaml
@@ -25,7 +25,7 @@ hmc_annealing_factor: 0.99
 use_hamiltonian_monte_carlo: false
 ridge_factor: 0.0
 use_pseudo_inverse: false
-pseudo_inverse_ridge_factor: 1e-4
+pseudo_inverse_ridge_factor: 0.0001
 animate_endeffector: false
 animate_endeffector_segment: "panda_rightfinger"
 joint_update_limit: 0.1


### PR DESCRIPTION
In Rolling I'm seeing [CI failures](https://github.com/moveit/moveit2/actions/runs/15565359776/job/43827980437?pr=2994#step:11:16455) for `launch_move_group_api.test.py` for the Chomp parameter `pseudo_inverse_ridge_factor`
![image](https://github.com/user-attachments/assets/ed2280cb-0e74-4e74-90b4-7cb72c00f65e)

This PR changes the value from `1e-4` to `0.0001`.
