### PR TITLE
Added an hardware type so the panda can move in gazebo/Ignition and added conditions to launch gz in the demo

### DIFF
--- a/panda_description/urdf/panda.urdf.xacro
+++ b/panda_description/urdf/panda.urdf.xacro
@@ -4,6 +4,11 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="panda" xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <link name="world"/>
+    <joint name="world_fixed" type="fixed">
+        <parent link="world"/>
+        <child link="panda_link0"/>
+    </joint>
     <link name="panda_link0">
         <visual>
             <geometry>

--- a/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_moveit_config/config/panda.ros2_control.xacro
@@ -14,6 +14,9 @@
                     <param name="joint_commands_topic">/isaac_joint_commands</param>
                     <param name="joint_states_topic">/isaac_joint_states</param>
                 </xacro:if>
+                <xacro:if value="${ros2_control_hardware_type == 'gz'}">
+                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+                </xacro:if>
             </hardware>
             <joint name="panda_joint1">
                 <command_interface name="position"/>

--- a/panda_moveit_config/config/panda.urdf.xacro
+++ b/panda_moveit_config/config/panda.urdf.xacro
@@ -1,7 +1,18 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
+
     <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
-    <xacro:arg name="ros2_control_hardware_type" default="mock_components" />
+    <xacro:arg name="ros2_control_hardware_type" default="gz"/>
+    <xacro:property name="ros2_control_hardware_type_property" value="$(arg ros2_control_hardware_type)" />
+    <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
+
+    <xacro:if value="${ros2_control_hardware_type_property == 'gz'}">
+        <gazebo>
+            <plugin name="ign_ros2_control::IgnitionROS2ControlPlugin" filename="libign_ros2_control-system.so">
+                <parameters>$(find moveit_resources_panda_moveit_config)/config/ros2_controllers.yaml</parameters>
+            </plugin>
+        </gazebo>
+    </xacro:if>
 
     <!-- Import panda urdf file -->
     <xacro:include filename="$(find moveit_resources_panda_description)/urdf/panda.urdf.xacro" />

--- a/panda_moveit_config/config/panda_hand.ros2_control.xacro
+++ b/panda_moveit_config/config/panda_hand.ros2_control.xacro
@@ -12,6 +12,9 @@
                     <param name="joint_commands_topic">/isaac_joint_commands</param>
                     <param name="joint_states_topic">/isaac_joint_states</param>
                 </xacro:if>
+                <xacro:if value="${ros2_control_hardware_type == 'gz'}">
+                    <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+                </xacro:if>
             </hardware>
             <joint name="panda_finger_joint1">
                 <command_interface name="position" />

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -1,7 +1,11 @@
 import os
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
+from launch.substitutions import (
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch.conditions import IfCondition
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -10,22 +14,44 @@ from moveit_configs_utils import MoveItConfigsBuilder
 
 
 def generate_launch_description():
-
     # Command-line arguments
     rviz_config_arg = DeclareLaunchArgument(
         "rviz_config",
         default_value="moveit.rviz",
         description="RViz configuration file",
     )
-
     db_arg = DeclareLaunchArgument(
-        "db", default_value="False", description="Database flag"
+        "db", default_value="False", description="Database flag."
+    )
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        "use_sim_time",
+        default_value="True",
+        description="Whether to use simulated clock.",
+    )
+
+    launch_gz_arg = DeclareLaunchArgument(
+        "launch_gz", default_value="True", description="Launch an empty gazebo world."
     )
 
     ros2_control_hardware_type = DeclareLaunchArgument(
         "ros2_control_hardware_type",
-        default_value="mock_components",
-        description="ROS 2 control hardware interface type to use for the launch file -- possible values: [mock_components, isaac]",
+        default_value="gz",
+        description="ROS 2 control hardware interface type to use for the launch file -- possible values: [mock_components, isaac, gz]",
+    )
+
+    gz_sim = ExecuteProcess(
+        cmd=["gz", "sim", "-v", "4", "-r", "empty.sdf"],
+        output="screen",
+        condition=IfCondition(LaunchConfiguration("launch_gz")),
+    )
+
+    sim_clock_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=["/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock"],
+        output="screen",
+        condition=IfCondition(LaunchConfiguration("launch_gz")),
     )
 
     moveit_config = (
@@ -54,7 +80,10 @@ def generate_launch_description():
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[moveit_config.to_dict()],
+        parameters=[
+            moveit_config.to_dict(),
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ],
         arguments=["--ros-args", "--log-level", "info"],
     )
 
@@ -75,6 +104,7 @@ def generate_launch_description():
             moveit_config.planning_pipelines,
             moveit_config.robot_description_kinematics,
             moveit_config.joint_limits,
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
         ],
     )
 
@@ -86,22 +116,47 @@ def generate_launch_description():
         output="log",
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "panda_link0"],
     )
-
     # Publish TF
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         name="robot_state_publisher",
         output="both",
-        parameters=[moveit_config.robot_description],
+        parameters=[
+            moveit_config.robot_description,
+            {"use_sim_time": LaunchConfiguration("use_sim_time")},
+        ],
     )
 
+    spawn_robot = Node(
+        package="ros_gz_sim",
+        executable="create",
+        arguments=[
+            "-name",
+            "panda",
+            "-topic",
+            "/robot_description",
+            "-x",
+            "0",
+            "-y",
+            "0",
+            "-z",
+            "0.1",
+        ],
+        output="screen",
+        condition=IfCondition(
+            PythonExpression(
+                ["'", LaunchConfiguration("ros2_control_hardware_type"), "' == 'gz'"]
+            )
+        ),
+    )
     # ros2_control using FakeSystem as hardware
     ros2_controllers_path = os.path.join(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
         "config",
         "ros2_controllers.yaml",
     )
+
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
@@ -110,6 +165,11 @@ def generate_launch_description():
             ("/controller_manager/robot_description", "/robot_description"),
         ],
         output="screen",
+        condition=IfCondition(
+            PythonExpression(
+                ["'", LaunchConfiguration("ros2_control_hardware_type"), "' != 'gz'"]
+            )
+        ),
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -120,18 +180,21 @@ def generate_launch_description():
             "--controller-manager",
             "/controller_manager",
         ],
+        parameters=[{"use_sim_time": LaunchConfiguration("use_sim_time")}],
     )
 
     panda_arm_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["panda_arm_controller", "-c", "/controller_manager"],
+        parameters=[{"use_sim_time": LaunchConfiguration("use_sim_time")}],
     )
 
     panda_hand_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["panda_hand_controller", "-c", "/controller_manager"],
+        parameters=[{"use_sim_time": LaunchConfiguration("use_sim_time")}],
     )
 
     # Warehouse mongodb server
@@ -150,9 +213,14 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            rviz_config_arg,
+            launch_gz_arg,
+            use_sim_time_arg,
             db_arg,
+            rviz_config_arg,
             ros2_control_hardware_type,
+            gz_sim,
+            sim_clock_bridge,
+            spawn_robot,
             rviz_node,
             static_tf_node,
             robot_state_publisher,

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -26,17 +26,17 @@ def generate_launch_description():
 
     use_sim_time_arg = DeclareLaunchArgument(
         "use_sim_time",
-        default_value="True",
+        default_value="False",
         description="Whether to use simulated clock.",
     )
 
     launch_gz_arg = DeclareLaunchArgument(
-        "launch_gz", default_value="True", description="Launch an empty gazebo world."
+        "launch_gz", default_value="False", description="Launch an empty gazebo world."
     )
 
     ros2_control_hardware_type = DeclareLaunchArgument(
         "ros2_control_hardware_type",
-        default_value="gz",
+        default_value="mock_components",
         description="ROS 2 control hardware interface type to use for the launch file -- possible values: [mock_components, isaac, gz]",
     )
 

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment.
        Commented the dependency until this works. -->
   <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->


### PR DESCRIPTION
I wanted to use the panda robot for gazebo but noticed it was not gazebo compatible. Therefore I added gz as a hardware type which use ign_ros2_controls. 

After I had done my implementation I noticed that there was an open PR for this already with the same idea of using ign_ros2_controls, by [HenningKayser](https://github.com/moveit/moveit_resources/pull/177) from 2023. I took inspiration and changed the demo.launch.py as well to be able to run gazebo if one would want to test the gazebo hardware. 

I figured that I would create a PR regardless if there is any interest in my version. 