### PR TITLE
Jazzy and newer migration: parallel_gripper_action_controller replaces gripper_controllers package

### DIFF
--- a/fanuc_moveit_config/package.xml
+++ b/fanuc_moveit_config/package.xml
@@ -36,7 +36,9 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
+  <!-- position_controllers was previously listed here but the fanuc
+       ros2_controllers.yaml does not load any controller from that package;
+       the dep was stale. The package is also gone from Rolling. -->
   <exec_depend>xacro</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment.
        Commented the dependency until this works. -->

--- a/panda_moveit_config/config/ros2_controllers.humble.yaml
+++ b/panda_moveit_config/config/ros2_controllers.humble.yaml
@@ -1,0 +1,49 @@
+# Humble override of ros2_controllers.yaml.
+#
+# Humble and Iron ship ros2_controllers <= 6.6 which provides the gripper
+# action controller under position_controllers/GripperActionController. Jazzy
+# and newer dropped that package; the equivalent class moved to
+# parallel_gripper_action_controller/GripperActionController and gained
+# additional parameters.
+#
+# The non-suffixed config/ros2_controllers.yaml carries the Jazzy+ form. This
+# file overrides it on Humble per the convention in
+# .github/DISTRO_COMPAT_POLICY.md §1.3 (in moveit2). The launch file resolves
+# the override via distro_specific_path() based on $ROS_DISTRO.
+#
+# Remove this file when Humble goes EOL (Pattern 1.3 cleanup rule).
+
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    panda_arm_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    panda_hand_controller:
+      type: position_controllers/GripperActionController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+
+panda_arm_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7
+    allow_nonzero_velocity_at_trajectory_end: true
+
+panda_hand_controller:
+  ros__parameters:
+    joint: panda_finger_joint1

--- a/panda_moveit_config/config/ros2_controllers.yaml
+++ b/panda_moveit_config/config/ros2_controllers.yaml
@@ -6,8 +6,9 @@ controller_manager:
     panda_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
+    # Jazzy and newer: parallel_gripper_action_controller replaces gripper_controllers package
     panda_hand_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
@@ -33,3 +34,17 @@ panda_arm_controller:
 panda_hand_controller:
   ros__parameters:
     joint: panda_finger_joint1
+
+    # Enable effort control (replacement for use_effort_interface)
+    max_effort_interface: "robotiq_85_left_knuckle_joint/effort"
+    max_effort: 50.0   # TODO tune
+
+    # Enable velocity/speed control (replacement for use_speed_interface)
+    max_velocity_interface: "robotiq_85_left_knuckle_joint/velocity"
+    max_velocity: 0.5    # TODO tune
+
+    # Optional (recommended)
+    state_interfaces: ["position", "velocity"]
+    allow_stalling: true
+    stall_timeout: 0.05
+    goal_tolerance: 0.02

--- a/panda_moveit_config/launch/demo.launch.py
+++ b/panda_moveit_config/launch/demo.launch.py
@@ -9,6 +9,27 @@ from ament_index_python.packages import get_package_share_directory
 from moveit_configs_utils import MoveItConfigsBuilder
 
 
+def distro_specific_path(package_share: str, base_relpath: str) -> str:
+    """Return a distro-overridable share-relative path.
+
+    ``<package_share>/<base_relpath>`` is the default form. A file at
+    ``<package_share>/<stem>.<ROS_DISTRO><ext>`` overrides it when the
+    ``ROS_DISTRO`` env var is set and the override file exists.
+
+    See .github/DISTRO_COMPAT_POLICY.md §1.3 for the broader policy.
+    Long-term this helper should live in ``moveit_configs_utils`` so
+    every launch using ``MoveItConfigsBuilder`` gets the behavior for
+    free.
+    """
+    distro = os.environ.get("ROS_DISTRO", "")
+    if distro:
+        stem, ext = os.path.splitext(base_relpath)
+        override = os.path.join(package_share, f"{stem}.{distro}{ext}")
+        if os.path.isfile(override):
+            return override
+    return os.path.join(package_share, base_relpath)
+
+
 def generate_launch_description():
 
     # Command-line arguments
@@ -96,11 +117,15 @@ def generate_launch_description():
         parameters=[moveit_config.robot_description],
     )
 
-    # ros2_control using FakeSystem as hardware
-    ros2_controllers_path = os.path.join(
+    # ros2_control using FakeSystem as hardware.
+    # The controller-class names in ros2_controllers.yaml differ between distros
+    # (Jazzy+ uses parallel_gripper_action_controller, Humble uses
+    # position_controllers). distro_specific_path() picks the Humble override
+    # config/ros2_controllers.humble.yaml when ROS_DISTRO=humble; falls back to
+    # the default file otherwise. See .github/DISTRO_COMPAT_POLICY.md §1.3.
+    ros2_controllers_path = distro_specific_path(
         get_package_share_directory("moveit_resources_panda_moveit_config"),
-        "config",
-        "ros2_controllers.yaml",
+        "config/ros2_controllers.yaml",
     )
     ros2_control_node = Node(
         package="controller_manager",

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -32,6 +32,7 @@
   <exec_depend>ros2cli_common_extensions</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>parallel_gripper_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>position_controllers</exec_depend>

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -32,10 +32,17 @@
   <exec_depend>ros2cli_common_extensions</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
-  <exec_depend>parallel_gripper_controller</exec_depend>
+  <!-- Gripper controller package was renamed in Jazzy:
+       https://github.com/ros-controls/ros2_controllers/pull/1913
+       removed position_controllers in favor of forward_command_controller +
+       parallel_gripper_action_controller (the latter lives in the
+       parallel_gripper_controller package). The position_controllers package
+       still exists on Humble/Iron; parallel_gripper_controller is only on
+       Jazzy and newer. -->
+  <exec_depend condition="$ROS_DISTRO == 'humble' or $ROS_DISTRO == 'iron'">position_controllers</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != 'humble' and $ROS_DISTRO != 'iron'">parallel_gripper_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment.


### PR DESCRIPTION
Basically a copy of the changes in https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/103

This should fix the CI failure in https://github.com/moveit/moveit2/pull/3626 (`gripper_controllers` has been deleted from rolling) - I do not know why we were not encountering this earlier.