### PR TITLE
CI: add jazzy and kilted, replace broken rolling jobs with rolling-resolute (experimental)

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -13,18 +13,24 @@ on:
 jobs:
   industrial_ci:
     strategy:
+      fail-fast: false
       matrix:
         env:
-          - {ROS_DISTRO: rolling, ROS_REPO: main}
-          - {ROS_DISTRO: rolling, ROS_REPO: testing}
+          # Rolling moved off Noble to Resolute. No prebuilt rolling-resolute base
+          # image exists yet (https://github.com/osrf/docker_images/issues/878), so
+          # omit DOCKER_IMAGE and let industrial_ci build on ubuntu:resolute,
+          # installing Rolling from ros-testing. Non-blocking until all moveit
+          # ecosystem deps are released for Resolute. Mirrors moveit/moveit2#3743.
+          - {ROS_DISTRO: rolling, OS_CODE_NAME: resolute, ROS_REPO: testing}
           - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: humble, ROS_REPO: testing}
 
     env:
       CCACHE_DIR: ~/.ccache
 
-    name: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
+    name: ${{ matrix.env.ROS_DISTRO }}${{ matrix.env.OS_CODE_NAME && format('-{0}', matrix.env.OS_CODE_NAME) || '' }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.OS_CODE_NAME == 'resolute' && ' (experimental)' || '' }}
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.env.OS_CODE_NAME == 'resolute' }}
     steps:
       - uses: actions/checkout@v4
       - uses: rhaschke/cache@main

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -22,6 +22,10 @@ jobs:
           # installing Rolling from ros-testing. Non-blocking until all moveit
           # ecosystem deps are released for Resolute. Mirrors moveit/moveit2#3743.
           - {ROS_DISTRO: rolling, OS_CODE_NAME: resolute, ROS_REPO: testing}
+          - {ROS_DISTRO: kilted, ROS_REPO: main}
+          - {ROS_DISTRO: kilted, ROS_REPO: testing}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main}
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing}
           - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: humble, ROS_REPO: testing}
 


### PR DESCRIPTION
## Description

The `rolling-main` and `rolling-testing` matrix jobs in `industrial_ci_action.yml` have been broken since Rolling moved off Ubuntu Noble to Ubuntu Resolute earlier this year. They fail at apt-install with `Unable to locate package ros-rolling-ros-environment` because the workflow runs on `ubuntu-22.04` (Jammy) and `rolling/distribution.yaml` now lists `release_platforms: ubuntu: [resolute]` exclusively. The last green CI run on `ros2` was 2025-06-12.

Because the matrix had the default `fail-fast: true`, the rolling failures cancelled the humble jobs too, leaving `ros2` with no CI signal at all. This silently surfaces on every PR opened against `ros2` (e.g. [#211](https://github.com/moveit/moveit_resources/pull/211)).

Adopt the strategy from [moveit/moveit2#3743](https://github.com/moveit/moveit2/pull/3743) — the rolling-resolute (experimental) pattern documented in [moveit2's distro compatibility policy §3](https://github.com/moveit/moveit2/blob/main/.github/DISTRO_COMPAT_POLICY.md):

- Replace the two `ROS_DISTRO: rolling` matrix entries with one `{ROS_DISTRO: rolling, OS_CODE_NAME: resolute, ROS_REPO: testing}` entry. industrial_ci builds the test container on `ubuntu:resolute` and installs Rolling from the `ros-testing` apt repo.
- Suffix the rolling-resolute job name with `(experimental)` and set `continue-on-error: true` for that entry. Until all moveit ecosystem deps are bloomed for Resolute, the job will be red for externally-blocked reasons; non-blocking keeps the humble signal usable.
- Drop `rolling-main` — `ros-testing` is the only repo where Rolling currently exists for Resolute.
- Set `fail-fast: false` so an experimental rolling failure doesn't cancel the humble jobs.

This change is independent of any code change in `moveit_resources` — it's pure CI configuration to restore green signal on the active branch.