### PR TITLE
panda_moveit_config: drop bogus robotiq interface refs from panda_hand_controller

### DIFF
--- a/panda_moveit_config/config/ros2_controllers.yaml
+++ b/panda_moveit_config/config/ros2_controllers.yaml
@@ -35,13 +35,12 @@ panda_hand_controller:
   ros__parameters:
     joint: panda_finger_joint1
 
-    # Enable effort control (replacement for use_effort_interface)
-    max_effort_interface: "robotiq_85_left_knuckle_joint/effort"
-    max_effort: 50.0   # TODO tune
-
-    # Enable velocity/speed control (replacement for use_speed_interface)
-    max_velocity_interface: "robotiq_85_left_knuckle_joint/velocity"
-    max_velocity: 0.5    # TODO tune
+    # parallel_gripper_action_controller drives panda_finger_joint1 via its
+    # position command interface; panda_hand.ros2_control.xacro does not expose
+    # effort or velocity command interfaces on the finger joint, so we leave
+    # max_effort_interface / max_velocity_interface unset. The controller falls
+    # back to pure position control, which is what panda's mock_components
+    # hardware supports.
 
     # Optional (recommended)
     state_interfaces: ["position", "velocity"]


### PR DESCRIPTION
The parallel_gripper_action_controller migration in #211 carried over robotiq_85_left_knuckle_joint references from a Robotiq config template:

    max_effort_interface: "robotiq_85_left_knuckle_joint/effort"
    max_velocity_interface: "robotiq_85_left_knuckle_joint/velocity"

`panda_hand.ros2_control.xacro` exposes only a position command interface on panda_finger_joint1, so the controller activation failed at runtime with:

    Unable to activate controller 'panda_hand_controller' since the command
    interface 'robotiq_85_left_knuckle_joint/effort' is not available.

Drop the max_effort_interface / max_velocity_interface settings (and their companion max_effort / max_velocity values). parallel_gripper_action_controller treats them as optional capabilities; without them it operates in pure position mode, which matches panda's mock_components hardware.

This surfaces because moveit2 PR #3762 fixes the test fixtures' static_transform_publisher invocation, which had been masking the controller failure on rolling-ci.